### PR TITLE
Fixed typo where create() call was missing from example.

### DIFF
--- a/docs/monster/ui/prettyCheck/create().md
+++ b/docs/monster/ui/prettyCheck/create().md
@@ -47,7 +47,7 @@ monster.ui.prettyCheck.create($('input'), 'radio');
 
 * Transform checkboxes and radios buttons
 ```javascript
-monster.ui.prettyCheck($('input'), 'all');
+monster.ui.prettyCheck.create($('input'), 'all');
 ```
 
 [monster]: ../../../monster.md


### PR DESCRIPTION
Line 50, changed monster.ui.prettyCheck(blah) to monster.ui.prettyCheck.create(blah).
