### PR TITLE
UI-1701: typo in sdk causes the user-portal quickcall to fail

### DIFF
--- a/js/lib/jquery.kazoosdk.js
+++ b/js/lib/jquery.kazoosdk.js
@@ -179,7 +179,7 @@
 			'delete': { verb: 'DELETE', url: 'accounts/{accountId}/devices/{deviceId}' },
 			'list': { verb: 'GET', url: 'accounts/{accountId}/devices' },
 			'getStatus': { verb: 'GET', url: 'accounts/{accountId}/devices/status' },
-			'quickcall': { verb: 'GET', url: 'accounts/{accountId}/users/{deviceId}/quickcall/{number}'},
+			'quickcall': { verb: 'GET', url: 'accounts/{accountId}/devices/{deviceId}/quickcall/{number}'},
 			'restart': { verb: 'POST', url: 'accounts/{accountId}/devices/{deviceId}/sync'}
 		},
 		media: {


### PR DESCRIPTION
Please backport to 3.20
