### PR TITLE
Fixed issue with error messages in monster.request

### DIFF
--- a/js/lib/monster.js
+++ b/js/lib/monster.js
@@ -91,15 +91,15 @@ define(function(require){
 			});
 
 			settings.error = function requestError (error, one, two, three) {
+				var parsedError = error;
+
 				monster.pub('monster.requestEnd');
 
+				if('response' in error && error.response) {
+					parsedError = $.parseJSON(error.response);
+				}
+
 				if(error.status === 402 && typeof options.acceptCharges === 'undefined') {
-					var parsedError = error;
-
-					if('response' in error && error.response) {
-						parsedError = $.parseJSON(error.response);
-					}
-
 					monster.ui.charges(parsedError.data, function() {
 						options.acceptCharges = true;
 						monster.request(options);


### PR DESCRIPTION
Error data wasn't being proliferated through when error wasn't a 402, parsedError variable wasn't being assigned in other branches.