### PR TITLE
UI-1918 use reseller's own service plans

### DIFF
--- a/apps/common/submodules/servicePlanDetails/servicePlanDetails.js
+++ b/apps/common/submodules/servicePlanDetails/servicePlanDetails.js
@@ -116,6 +116,7 @@ define(function(require){
 			var self = this,
 				args = pArgs,
 				mode = pArgs.mode || 'edit',
+				useOwnPlans = pArgs.useOwnPlans || false,
 				accountId = args.accountId || self.accountId;
 
 			monster.parallel({
@@ -135,7 +136,7 @@ define(function(require){
 
 									_.each(data.plans, function(v,k) {
 										listSP[k] = function(callback) {
-											self.servicePlanDetailsGetSP(k, accountId, function(detailSP) {
+											self.servicePlanDetailsGetSP(k, accountId, false, function(detailSP) {
 												callback && callback(null, detailSP);
 											});
 										}
@@ -154,7 +155,7 @@ define(function(require){
 						}
 					},
 					listAvailable: function(callback) {
-						self.servicePlanDetailsListSP(accountId, function(data) {
+						self.servicePlanDetailsListSP(accountId, useOwnPlans, function(data) {
 							callback(null, data)
 						});
 					}
@@ -185,7 +186,7 @@ define(function(require){
 
 						if(servicePlanId !== 'none') {
 							$this.parents('.category-wrapper').addClass('has-selected');
-							self.servicePlanDetailsGetSP(servicePlanId, accountId, function(data) {
+							self.servicePlanDetailsGetSP(servicePlanId, accountId, useOwnPlans, function(data) {
 								self.servicePlanDetailsRender({ accountId: accountId, servicePlan: data, container: divContainer });
 							});
 						} else {
@@ -415,11 +416,11 @@ define(function(require){
 			});
 		},
 
-		servicePlanDetailsListSP: function(accountId, callback) {
+		servicePlanDetailsListSP: function(accountId, useOwnPlans, callback) {
 			var self = this;
 
 			self.callApi({
-				resource: 'servicePlan.listAvailable',
+				resource: useOwnPlans ? 'servicePlan.list' : 'servicePlan.listAvailable',
 				data: {
 					accountId: accountId
 				},
@@ -429,11 +430,11 @@ define(function(require){
 			});
 		},
 
-		servicePlanDetailsGetSP: function(planId, accountId, callback) {
+		servicePlanDetailsGetSP: function(planId, accountId, useOwnPlans, callback) {
 			var self = this;
 
 			self.callApi({
-				resource: 'servicePlan.getAvailable',
+				resource: useOwnPlans ? 'servicePlan.get' : 'servicePlan.getAvailable',
 				data: {
 					planId: planId,
 					accountId: accountId


### PR DESCRIPTION
Adds additional argument 'useOwnPlans', which is set to true for resellers. This allows a reseller to assign his own service plans instead of his parent's service plans. Affects only the "Add New Account" wizard.

See the corresponding pull request for the monster-ui-accounts repo (https://github.com/2600hz/monster-ui-accounts/pull/8)