### PR TITLE
fix(accounts): Coerce numerics to strings during search

### DIFF
--- a/apps/common/submodules/accountBrowser/accountBrowser.js
+++ b/apps/common/submodules/accountBrowser/accountBrowser.js
@@ -147,7 +147,7 @@ define(function(require){
 				var found = false;
 
 				_.each(data, function(val) {
-					if(val.toLowerCase().indexOf(searchString.toLowerCase()) >= 0) {
+					if(val.toString().toLowerCase().indexOf(searchString.toLowerCase()) >= 0) {
 						found = true;
 					}
 				});


### PR DESCRIPTION
Its possible that the data stored in the DOM, and retrieved using jQuery's data() function could return a numeric value. By casting this to a string before calling toLowerCase() we prevent any exception that would break search. This is possible in cases where the data returned is of the form...

```json
      {
          "id": "asdfasfdsadsasdf",
          "name": 1234,
          "realm": "1234.something.com"
      }
```