### PR TITLE
Numbers formatting US Regex should only match US numbers

### DIFF
--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -264,7 +264,7 @@ define(function(require){
 
 				if(length >= 10 && length <= 12) {
 					// Try US Regex
-					phoneNumber = phoneNumber.replace(/\+?1?([2-9][0-9]{2})([2-9][0-9]{2})([0-9]{4})$/, '+1 ($1) $2-$3');
+					phoneNumber = phoneNumber.replace(/^\+?1?([2-9][0-9]{2})([2-9][0-9]{2})([0-9]{4})$/, '+1 ($1) $2-$3');
 				}
 			}
 


### PR DESCRIPTION
Hi,
this fix should prevent strange formatting of non US numbers, with length between 10 and 12 digits.
For example, without this, number "+3531xxxyyzz", will be turned into: "+3+1 (531) xxx-yyzz"
Thanks,
Mario