### PR TITLE
UI-2699: Fix event binding on spinner start

### DIFF
--- a/src/apps/core/app.js
+++ b/src/apps/core/app.js
@@ -28,10 +28,12 @@ define(function(require) {
 		//Default app to render if the user is logged in, can be changed by setting a default app
 		_defaultApp: 'appstore',
 
-		// Global var used to show the loading gif
-		spinner: {
-			requestAmount: 0,
-			active: false
+		spinner: {},
+
+		// Global var to determine if there is a request in progress
+		request: {
+			active: false,
+			counter: 0
 		},
 
 		appFlags: {},
@@ -575,46 +577,45 @@ define(function(require) {
 			});
 		},
 
-		onRequestStart: function(spinner) {
+		onRequestStart: function($spinner) {
 			var self = this,
 				waitTime = 250;
 
-			self.spinner.requestAmount++;
+			self.request.counter++;
 
 			// If we start a request, we cancel any existing timeout that was checking if the loading was over
 			clearTimeout(self.spinner.endTimeout);
 
-			if (self.spinner.requestAmount) {
-				self.spinner.active = true;
-				monster.pub('core.onSpinnerStart');
+			if (self.request.counter) {
+				self.request.active = true;
 			}
 
 			// And we start a timeout that will check if there are still some active requests after %waitTime%.
 			// If yes, it will then show the spinner. We do this to avoid showing the spinner to often, and just show it on long requests.
 			self.spinner.startTimeout = setTimeout(function() {
-				if (self.spinner.requestAmount && !spinner.hasClass('active')) {
-					spinner.addClass('active');
+				if (self.request.counter && !$spinner.hasClass('active')) {
+					$spinner.addClass('active');
 				}
 
 				clearTimeout(self.spinner.startTimeout);
 			}, waitTime);
 		},
 
-		onRequestEnd: function(spinner) {
+		onRequestEnd: function($spinner) {
 			var self = this,
 				waitTime = 50;
 
-			self.spinner.requestAmount--;
+			self.request.counter--;
 
 			// If there are no active requests, we set a timeout that will check again after %waitTime%
 			// If there are no active requests after the timeout, then we can safely remove the spinner.
 			// We do this to avoid showing and hiding the spinner too quickly
-			if (!self.spinner.requestAmount) {
-				self.spinner.active = false;
+			if (!self.request.counter) {
+				self.request.active = false;
 
 				self.spinner.endTimeout = setTimeout(function() {
-					if (spinner.hasClass('active')) {
-						spinner.removeClass('active');
+					if ($spinner.hasClass('active')) {
+						$spinner.removeClass('active');
 					}
 
 					clearTimeout(self.spinner.startTimeout);

--- a/src/js/lib/monster.js
+++ b/src/js/lib/monster.js
@@ -88,6 +88,9 @@ define(function(require){
 		},
 
 		request: function(options){
+console.log(
+	'request: 	', options.resource
+);
 			var self = this,
 				settings =  _.extend({}, this._requests[options.resource]);
 

--- a/src/js/lib/monster.js
+++ b/src/js/lib/monster.js
@@ -88,9 +88,6 @@ define(function(require){
 		},
 
 		request: function(options){
-console.log(
-	'request: 	', options.resource
-);
 			var self = this,
 				settings =  _.extend({}, this._requests[options.resource]);
 

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -310,6 +310,7 @@ define(function(require){
 		 * @param  {Object}   pOptions   loading view options
 		 */
 		insertTemplate: function($container, callback, pOptions) {
+console.log('--------------------');
 			var coreApp = monster.apps.core,
 				options = $.extend(true, {
 					title: coreApp.i18n.active().insertTemplate.title,
@@ -321,15 +322,19 @@ define(function(require){
 					text: options.text
 				},
 				loadingTemplate = monster.template(coreApp, 'monster-insertTemplate', dataToTemplate),
-				appendTemplate = function(template, fadeInCallback) {
+				appendTemplate = function(template, fadeInCallback, isLocal) {
+console.time(isLocal ? 'loading' : 'callback');
 					$container
 						.empty()
 						.hide()
 						.append(template)
-						.fadeIn(options.duration, fadeInCallback);
+						.fadeIn(options.duration, function() {
+console.timeEnd(isLocal ? 'loading' : 'callback');
+							fadeInCallback && fadeInCallback();
+						});
 				};
 
-			appendTemplate(loadingTemplate);
+			appendTemplate(loadingTemplate, undefined, true);
 
 			callback(appendTemplate);
 		},

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -310,10 +310,6 @@ define(function(require){
 		 * @param  {Object}   pOptions   loading view options
 		 */
 		insertTemplate: function($container, callback, pOptions) {
-console.log('----------------------------------------');
-console.log(
-	'callee: 	', arguments.callee.caller.name
-);
 			var coreApp = monster.apps.core,
 				options = $.extend(true, {
 					title: coreApp.i18n.active().insertTemplate.title,
@@ -325,33 +321,17 @@ console.log(
 					text: options.text
 				},
 				loadingTemplate = monster.template(coreApp, 'monster-insertTemplate', dataToTemplate),
-				appendTemplate = function(template, fadeInCallback, isLocal) {
-console.log(
-	'template: 	', isLocal ? 'loading' : 'application'
-);
-					if (subscription) {
-						monster.unsub(subscription);
-					}
-
+				appendTemplate = function(template, fadeInCallback) {
 					$container
 						.empty()
 						.hide()
 						.append(template)
 						.fadeIn(options.duration, fadeInCallback);
-				},
-				subscription;
-console.log(
-	'title: 		', options.title
-);
-			callback(appendTemplate);
+				};
 
-			if (monster.apps.core.spinner.active) {
-				appendTemplate(loadingTemplate, undefined, true);
-			} else {
-				subscription = monster.sub('core.onSpinnerStart', function() {
-					appendTemplate(loadingTemplate, undefined, true);
-				});
-			}
+			appendTemplate(loadingTemplate);
+
+			callback(appendTemplate);
 		},
 
 		// When the developer wants to use steps, he can just send an object like { range: 'max', steps: [30,3600,18880], value: 30 }

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -310,7 +310,6 @@ define(function(require){
 		 * @param  {Object}   pOptions   loading view options
 		 */
 		insertTemplate: function($container, callback, pOptions) {
-console.log('--------------------');
 			var coreApp = monster.apps.core,
 				options = $.extend(true, {
 					title: coreApp.i18n.active().insertTemplate.title,
@@ -322,21 +321,20 @@ console.log('--------------------');
 					text: options.text
 				},
 				loadingTemplate = monster.template(coreApp, 'monster-insertTemplate', dataToTemplate),
-				appendTemplate = function(template, fadeInCallback, isLocal) {
-console.time(isLocal ? 'loading' : 'callback');
+				appendTemplate = function(template, fadeInCallback) {
 					$container
 						.empty()
 						.hide()
 						.append(template)
-						.fadeIn(options.duration, function() {
-console.timeEnd(isLocal ? 'loading' : 'callback');
-							fadeInCallback && fadeInCallback();
-						});
+						.fadeIn(options.duration, fadeInCallback);
 				};
 
-			appendTemplate(loadingTemplate, undefined, true);
-
 			callback(appendTemplate);
+
+			// Only insert the loading template if a request is in progress
+			if (monster.apps.core.request.active) {
+				appendTemplate(loadingTemplate);
+			}
 		},
 
 		// When the developer wants to use steps, he can just send an object like { range: 'max', steps: [30,3600,18880], value: 30 }

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -310,6 +310,10 @@ define(function(require){
 		 * @param  {Object}   pOptions   loading view options
 		 */
 		insertTemplate: function($container, callback, pOptions) {
+console.log('----------------------------------------');
+console.log(
+	'callee: 	', arguments.callee.caller.name
+);
 			var coreApp = monster.apps.core,
 				options = $.extend(true, {
 					title: coreApp.i18n.active().insertTemplate.title,
@@ -321,7 +325,10 @@ define(function(require){
 					text: options.text
 				},
 				loadingTemplate = monster.template(coreApp, 'monster-insertTemplate', dataToTemplate),
-				appendTemplate = function(template, fadeInCallback) {
+				appendTemplate = function(template, fadeInCallback, isLocal) {
+console.log(
+	'template: 	', isLocal ? 'loading' : 'application'
+);
 					if (subscription) {
 						monster.unsub(subscription);
 					}
@@ -333,14 +340,16 @@ define(function(require){
 						.fadeIn(options.duration, fadeInCallback);
 				},
 				subscription;
-
+console.log(
+	'title: 		', options.title
+);
 			callback(appendTemplate);
 
 			if (monster.apps.core.spinner.active) {
-				appendTemplate(loadingTemplate);
+				appendTemplate(loadingTemplate, undefined, true);
 			} else {
 				subscription = monster.sub('core.onSpinnerStart', function() {
-					appendTemplate(loadingTemplate);
+					appendTemplate(loadingTemplate, undefined, true);
 				});
 			}
 		},


### PR DESCRIPTION
Separate spinner and request detection logic and and the latter instead of the former to show the loading template.