### PR TITLE
Update portListing.js

### DIFF
--- a/src/apps/common/submodules/portListing/portListing.js
+++ b/src/apps/common/submodules/portListing/portListing.js
@@ -727,7 +727,7 @@ define(function(require) {
 							var date = dialog.find('#scheduled_date').datepicker('getDate'),
 								time = dialog.find('#scheduled_time').timepicker('getSecondsFromMidnight') / 60,
 								year = date.getFullYear(),
-								month = self.portListingFormat2Digits(date.getMonth()),
+								month = self.portListingFormat2Digits(date.getMonth()+1),
 								day = self.portListingFormat2Digits(date.getDate()),
 								hours = self.portListingFormat2Digits(Math.floor(time / 60)),
 								minutes = self.portListingFormat2Digits(time % 60),


### PR DESCRIPTION
dateObj.getMonth() is an integer number, between 0 and 11. You should add 1 in order to get correct date string.