### PR TITLE
Bring port app dialog to the front

### DIFF
--- a/src/apps/common/submodules/portListing/portListing.scss
+++ b/src/apps/common/submodules/portListing/portListing.scss
@@ -579,7 +579,9 @@
 }
 
 /*********************** STATUS POPUP ***********************/
-
+.port-app-dialog {
+	z-index:1001;	
+}
 .port-app-dialog #form_update_status {
 	max-width: 500px;
 	margin: 0;


### PR DESCRIPTION
Quick fix to bring port app dialog to the front. Currently is covered by modal with default z-index:1000; Maybe it could be attached to different element in order to fix that too. This is quick fix.