### PR TITLE
Fix race condition when binding multiple listeners to websocket

### DIFF
--- a/src/js/lib/monster.socket.js
+++ b/src/js/lib/monster.socket.js
@@ -234,12 +234,11 @@ define(function(require) {
 					self.log('already bound!', true);
 				}
 			} else {
+				self.bindings[binding] = {
+					listeners: [ newListener ]
+				};
 				self.subscribe(accountId, authToken, binding, function(result) {
-					if (result.status === 'success') {
-						self.bindings[binding] = {
-							listeners: [ newListener ]
-						};
-					} else {
+					if (result.status !== 'success') {
 						self.log('monster.socket: subscribe ' + binding + ' failed', true);
 						self.log(result);
 					}


### PR DESCRIPTION
When two bindings are created in close succession (to the same routing key), one can overwrite the other. 