### PR TITLE
Add alternative apploader

### DIFF
--- a/src/apps/apploader/app.js
+++ b/src/apps/apploader/app.js
@@ -59,7 +59,7 @@ define(function(require) {
 			var self = this;
 
 			if (monster.config.whitelabel.useDropdownApploader) {
-				return $('#apploader').length !== 0;
+				return $('.app-list-dropdown-wrapper').length !== 0;
 			} else {
 				return typeof self.appFlags.modal !== 'undefined';
 			}
@@ -84,60 +84,57 @@ define(function(require) {
 						template = $(monster.template(self, 'appList', {
 							defaultApp: appList[0],
 							apps: appList,
-							useDropdownApploader: true,
 							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin' && monster.config.whitelabel.showAppstoreInDropdown
 						}));
+
 						$('#appList').empty().append(template);
+
+						self.bindDropdownApploaderEvents(template);
 					} else {
 						template = $(monster.template(self, 'app', {
 							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin',
 							defaultApp: monster.ui.formatIconApp(appList[0]),
 							apps: appList
 						}));
-					}
 
-					self.bindEvents(template, appList);
+						self.bindEvents(template, appList);
 
-					if (!monster.config.whitelabel.useDropdownApploader) {
 						self.appFlags.modal = monster.ui.fullScreenModal(template, {
 							hideClose: true,
 							destroyOnClose: false
 						});
 					}
-
 				});
 			} else {
 				self.show();
 			}
 		},
 
-		bindEvents: function(parent, appList) {
+		bindDropdownApploaderEvents: function(parent) {
 			var self = this;
 
-			if (monster.config.whitelabel.useDropdownApploader) {
-				parent.find('.appSelector').on('click', function() {
-					var $this = $(this),
-						appName = $this.data('name');
+			parent.find('.appSelector').on('click', function() {
+				var $this = $(this),
+					appName = $this.data('name');
 
-					if (appName) {
-						monster.apps.load(appName, function(app) {
-							app.render();
-							monster.pub('core.showAppName', appName);
-							monster.pub('myaccount.hide');
-						});
-					}
-				});
-				return;
-			}
-		
-			updateAppInfo = function updateAppInfo(id) {
-				var app = appList.filter(function(v) { return id === v.id; })[0];
-				parent.find('.app-description')
-					.find('h4')
-						.text(app.label)
-					.addBack().find('p')
-						.text(app.description);
-			};
+				if (appName) {
+					monster.routing.goTo('apps/' + appName);
+				}
+			});
+		},
+
+		bindEvents: function(parent, appList) {
+			var self = this,
+				updateAppInfo = function updateAppInfo(id) {
+					var app = appList.filter(function(v) { return id === v.id; })[0];
+
+					parent.find('.app-description')
+							.find('h4')
+							.text(app.label)
+							.addBack()
+							.find('p')
+							.text(app.description);
+				};
 
 			setTimeout(function() { parent.find('.search-query').focus(); });
 
@@ -289,18 +286,7 @@ define(function(require) {
 		show: function() {
 			var self = this;
 
-			if (monster.config.whitelabel.useDropdownApploader) {
-				apploader = $('#apploader');
-
-				if (!apploader.hasClass('active')) {
-					monster.pub('myaccount.hide');
-					apploader
-						.addClass('active')
-						.fadeIn(250, function() {
-							$('#monster-content').hide();
-						});
-				}
-			} else {
+			if (!monster.config.whitelabel.hasOwnProperty('useDropdownApploader') || monster.config.whitelabel.useDropdownApploader === false) {
 				self.appFlags.modal.open();
 			}
 		},
@@ -308,24 +294,7 @@ define(function(require) {
 		_hide: function() {
 			var self = this;
 
-			if (monster.config.whitelabel.useDropdownApploader) {
-				apploader = $('#apploader');
-
-					if (apploader.hasClass('active')) {
-						$('#monster-content').show();
-						apploader
-							.removeClass('active')
-							.fadeOut(250, function() {
-								// Put the default app at the beginning of the list in the DOM
-								if (defaultAppId !== apploader.find('.right-div .app-element').first().data('id')) {
-									var defaultAppId = apploader.find('.left-div .app-element').data('id');
-									apploader.find('.right-div .app-list')
-										.prepend(apploader.find('.right-div .app-element[data-id="' + defaultAppId + '"]'));
-								}
-							});
-					}
-
-			} else {
+			if (!monster.config.whitelabel.hasOwnProperty('useDropdownApploader') || monster.config.whitelabel.useDropdownApploader === false) {
 				if (self.appFlags.modal) {
 					self.appFlags.modal.close();
 				}
@@ -336,11 +305,13 @@ define(function(require) {
 			var self = this;
 
 			if (self.isRendered()) {
-				self.appFlags.modal.toggle();
-				var apploader = $('#apploader');
+				if (!monster.config.whitelabel.hasOwnProperty('useDropdownApploader') || monster.config.whitelabel.useDropdownApploader === false) {
+					self.appFlags.modal.toggle();
+					var apploader = $('#apploader');
 
-				if (self.appFlags.modal.isVisible()) {
-					apploader.find('.search-query').val('').focus();
+					if (self.appFlags.modal.isVisible()) {
+						apploader.find('.search-query').val('').focus();
+					}
 				}
 			} else {
 				self.render();

--- a/src/apps/apploader/app.js
+++ b/src/apps/apploader/app.js
@@ -84,7 +84,7 @@ define(function(require) {
 						template = $(monster.template(self, 'appList', {
 							defaultApp: appList[0],
 							apps: appList,
-							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin' && monster.config.whitelabel.showAppstoreInDropdown
+							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin'
 						}));
 
 						$('#appList').empty().append(template);

--- a/src/apps/apploader/style/app.scss
+++ b/src/apps/apploader/style/app.scss
@@ -291,3 +291,102 @@
 		margin-top: 15px !important;
 	}
 }
+
+/************************************************************/
+/*********************** App List ***************************/
+/************************************************************/
+
+/* CREDIT: Andor Nagy */
+/* SOURCE: http://codepen.io/andornagy/pen/xhiJH */
+
+#appList {
+	width: 150px;
+	background-color: #303039;
+}
+
+#appList,
+#appList ul {
+	padding:0;
+	margin:0;
+	list-style: none;
+	position: relative;
+}
+
+#appList li {
+	display:inline-block;
+	background-color: #303039;
+}
+
+#appList a {
+	display:block;
+	padding:0 10px;
+	color: #c0c0c9;
+	font-size: 14px;
+	line-height: 60px;
+	text-decoration:none;
+}
+
+#appList a > i{
+	vertical-align: middle;
+	color: #c0c0c9;
+}
+
+#appList a:hover {
+	color: #22A5FF;
+}
+
+/* Hide Dropdowns by Default */
+#appList, #appList ul {
+	display: none;
+	position: absolute;
+	top: 67px; /* the height of the main #apploader including border */
+	z-index : 200;
+}
+
+/* Display Dropdowns on Hover */
+#main_topbar_apploader:hover #appList,
+#appList li:hover > ul {
+	display:block;
+}
+
+/* First Tier Dropdown */
+#appList li {
+	width: 150px;
+	float:none;
+	display:list-item;
+	position: relative;
+	z-index : 200;
+}
+
+#appList li a{
+	line-height:40px;
+}
+
+/* Second, Third and more Tiers	*/
+#appList li ul li {
+	position: relative;
+	top: -60px;
+	left: -151px;
+	min-height: 40px;
+	border-right: 1px solid #202029;
+	z-index : 200;
+}
+
+#appList li ul li > a{
+	font-size: 12px;
+	line-height: 20px;
+}
+
+#appList li ul li > a:hover {
+	color: #c0c0c9;
+}
+
+#appList a[data-name="appstore"] {
+	border-top: 1px solid #202029;
+	color: #fff;
+}
+
+#appList a[data-name="appstore"]:hover {
+	color: #22A5FF;
+}
+

--- a/src/apps/apploader/style/app.scss
+++ b/src/apps/apploader/style/app.scss
@@ -54,7 +54,7 @@
 	transition: transform .15s ease-in, box-shadow .062s ease-in;
 }
 
-#apploader .app-element:hover .app-icon { 
+#apploader .app-element:hover .app-icon {
 	box-shadow: 0 0 20px 0 rgba(0,0,0,0.2),0 5px 5px 0 rgba(0,0,0,0.24);
 	transform: scale(1.15);
 }

--- a/src/apps/apploader/views/appList.html
+++ b/src/apps/apploader/views/appList.html
@@ -1,21 +1,24 @@
-{{#each apps}}
-<li>
-	<a href="#" class="appSelector" data-name="{{this.name}}" data-id="{{this.id}}">{{this.label}}</a>
-	<ul>
+<div class="app-list-dropdown-wrapper">
+	{{#each apps}}
 		<li>
-			<a>
-				{{#if this.description}}
-					{{this.description}}
-				{{else}}
-					{{i18n.noDescription}}
-				{{/if}}
-			</a>
+			<a href="javascript:void(0);" class="appSelector" data-name="{{this.name}}" data-id="{{this.id}}">{{this.label}}</a>
+			<ul>
+				<li>
+					<a>
+						{{#if this.description}}
+							{{this.description}}
+						{{else}}
+							{{i18n.noDescription}}
+						{{/if}}
+					</a>
+				</li>
+			</ul>
 		</li>
-	</ul>
-</li>
-{{/each}}
-{{#if allowAppstore}}
-<li>
-	<a href="#" class="appSelector" data-name="appstore">{{i18n.appstore.button}}</a>
-</li>
-{{/if}}
+	{{/each}}
+
+	{{#if allowAppstore}}
+		<li>
+			<a href="#" class="appSelector" data-name="appstore">{{i18n.appstore.button}}</a>
+		</li>
+	{{/if}}
+</div>

--- a/src/apps/apploader/views/appList.html
+++ b/src/apps/apploader/views/appList.html
@@ -1,0 +1,21 @@
+{{#each apps}}
+<li>
+	<a href="#" class="appSelector" data-name="{{this.name}}" data-id="{{this.id}}">{{this.label}}</a>
+	<ul>
+		<li>
+			<a>
+				{{#if this.description}}
+					{{this.description}}
+				{{else}}
+					{{i18n.noDescription}}
+				{{/if}}
+			</a>
+		</li>
+	</ul>
+</li>
+{{/each}}
+{{#if allowAppstore}}
+<li>
+	<a href="#" class="appSelector" data-name="appstore">{{i18n.appstore.button}}</a>
+</li>
+{{/if}}

--- a/src/apps/core/app.js
+++ b/src/apps/core/app.js
@@ -64,7 +64,8 @@ define(function(require) {
 					jiraFeedback: {
 						enabled: monster.config.whitelabel.hasOwnProperty('jiraFeedback') && monster.config.whitelabel.jiraFeedback.enabled === true,
 						url: monster.config.whitelabel.hasOwnProperty('jiraFeedback') ? monster.config.whitelabel.jiraFeedback.url : ''
-					}
+					},
+					useDropdownApploader: monster.config.whitelabel.useDropdownApploader
 				},
 				mainTemplate = $(monster.template(self, 'app', dataTemplate));
 
@@ -265,7 +266,9 @@ define(function(require) {
 				self.onRequestEnd(spinner);
 			});
 
-			container.find('#main_topbar_apploader_link').on('click', function(e) {
+			// Different functionality depending on whether default apploader or dropdown apploader to be opened
+			var eventType = monster.config.whitelabel.useDropdownApploader ? 'mouseover' : 'click';
+			container.find('#main_topbar_apploader_link').on(eventType, function(e) {
 				e.preventDefault();
 				monster.pub('apploader.toggle');
 			});

--- a/src/apps/core/app.js
+++ b/src/apps/core/app.js
@@ -664,14 +664,6 @@ define(function(require) {
 						}
 					},
 					{
-						category: 'general',
-						key: '#',
-						title: self.i18n.active().globalShortcuts.keys['#'].title,
-						callback: function() {
-							monster.pub('apploader.toggle');
-						}
-					},
-					{
 						adminOnly: true,
 						category: 'general',
 						key: 'a',
@@ -731,6 +723,17 @@ define(function(require) {
 						}
 					}
 				];
+
+			if (!monster.config.whitelabel.hasOwnProperty('useDropdownApploader') || monster.config.whitelabel.useDropdownApploader === false) {
+				shortcuts.push({
+					category: 'general',
+					key: '#',
+					title: self.i18n.active().globalShortcuts.keys['#'].title,
+					callback: function() {
+						monster.pub('apploader.toggle');
+					}
+				});
+			}
 
 			_.each(shortcuts, function(shortcut) {
 				monster.ui.addShortcut(shortcut);

--- a/src/apps/core/views/app.html
+++ b/src/apps/core/views/app.html
@@ -17,7 +17,9 @@
 				</div>
 			</li>
 			<li id="main_topbar_apploader">
-				<a href="javascript:void(0);" class="links" id="main_topbar_apploader_link" data-original-title="{{i18n.apps}}" data-placement="bottom" data-toggle="tooltip">
+        <ul id="appList">
+        </ul>
+        <a href="javascript:void(0);" class="links" id="main_topbar_apploader_link" {{#unless useDropdownApploader}}data-original-title="{{i18n.apps}}" data-placement="bottom" data-toggle="tooltip"{{/unless}}>
 					<i class="icon-telicon-apps"></i>
 				</a>
 			</li>

--- a/src/apps/core/views/app.html
+++ b/src/apps/core/views/app.html
@@ -17,9 +17,8 @@
 				</div>
 			</li>
 			<li id="main_topbar_apploader">
-        <ul id="appList">
-        </ul>
-        <a href="javascript:void(0);" class="links" id="main_topbar_apploader_link" {{#unless useDropdownApploader}}data-original-title="{{i18n.apps}}" data-placement="bottom" data-toggle="tooltip"{{/unless}}>
+				<ul id="appList"></ul>
+				<a href="javascript:void(0);" class="links" id="main_topbar_apploader_link" {{#unless useDropdownApploader}}data-original-title="{{i18n.apps}}" data-placement="bottom" data-toggle="tooltip"{{/unless}}>
 					<i class="icon-telicon-apps"></i>
 				</a>
 			</li>

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -79,7 +79,12 @@ define(function(require) {
 			jiraFeedback: {
 				enabled: false,
 				url: ''
-			}
+			},
+
+			// If set to true, the apploader will render as a dropdown list instead of a page on top of the window. False by default.
+			//useDropdownApploader: true,
+			// If set to true, admins will be shown an appstore link at the bottom of the apploader.
+			//showAppstoreInDropdown: true,
 		},
 		developerFlags: {
 			// Setting this flag to true will show all restricted callflows in the Callflows app

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -83,8 +83,6 @@ define(function(require) {
 
 			// If set to true, the apploader will render as a dropdown list instead of a page on top of the window. False by default.
 			//useDropdownApploader: true,
-			// If set to true, admins will be shown an appstore link at the bottom of the apploader.
-			//showAppstoreInDropdown: true,
 		},
 		developerFlags: {
 			// Setting this flag to true will show all restricted callflows in the Callflows app


### PR DESCRIPTION
This change would allow an alternative apploader to be used, if desired, by enabling and configuring it through settings in config.js. This alternative apploader is a drop-down menu of apps, which is faster to select from and could be a more practical option for accounts with few apps. Additionally, it is possible to choose whether or not to expose the App Store in the drop-down - if not enabled via config.js, it will be hidden from admins too.