### PR TITLE
Add flag for hiding appstore from all users

### DIFF
--- a/src/apps/apploader/app.js
+++ b/src/apps/apploader/app.js
@@ -84,7 +84,7 @@ define(function(require) {
 						template = $(monster.template(self, 'appList', {
 							defaultApp: appList[0],
 							apps: appList,
-							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin'
+							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin' && !monster.config.whitelabel.hideAppStore
 						}));
 
 						$('#appList').empty().append(template);
@@ -92,7 +92,7 @@ define(function(require) {
 						self.bindDropdownApploaderEvents(template);
 					} else {
 						template = $(monster.template(self, 'app', {
-							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin',
+							allowAppstore: monster.apps.auth.currentUser.priv_level === 'admin' && !monster.config.whitelabel.hideAppStore,
 							defaultApp: monster.ui.formatIconApp(appList[0]),
 							apps: appList
 						}));

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -83,6 +83,9 @@ define(function(require) {
 
 			// If set to true, the apploader will render as a dropdown list instead of a page on top of the window. False by default.
 			//useDropdownApploader: true,
+
+			// The appstore is exposed to admins by default. If set to false, it will be hidden for all users.
+			// hideAppStore: true
 		},
 		developerFlags: {
 			// Setting this flag to true will show all restricted callflows in the Callflows app


### PR DESCRIPTION
The appstore is exposed to admin users by default. Setting the new hideAppStore flag to true in the config file will hide the appstore from all users.