### PR TITLE
Add preflow selection to account settings

### DIFF
--- a/src/apps/myaccount/app.js
+++ b/src/apps/myaccount/app.js
@@ -940,6 +940,10 @@ define(function(require) {
 						params.data.ui_flags.numbers_format_exceptions = newData.ui_flags.numbers_format_exceptions;
 					}
 				}
+				// Remove preflow when user sets it to be none
+				if(params.data.preflow && params.data.preflow.always && params.data.preflow.always === 'none') {
+					delete params.data.preflow.always;
+				}
 			} else if (type === 'billing') {
 				params.data = newData;
 			}

--- a/src/apps/myaccount/i18n/en-US.json
+++ b/src/apps/myaccount/i18n/en-US.json
@@ -77,6 +77,11 @@
 		"accountName": "Account Name",
 		"accountId": "Account ID",
 
+		"none": "No Preflow",
+		"preflow": "Preflow",
+		"preflowTitle": "Preflow",
+		"preflowHelp": "A preflow is a callflow that is used before any callflow under this account",
+
 		"accountRealm": "Account Realm",
 
 		"technicalContact": "Technical Contact",

--- a/src/apps/myaccount/submodules/account/account.js
+++ b/src/apps/myaccount/submodules/account/account.js
@@ -79,6 +79,46 @@ define(function(require) {
 			});
 		},
 
+		accountGetCallflows: function(callback) {
+			var self = this;
+
+			self.callApi({
+				resource: 'callflow.list',
+				data: {
+					accountId: self.accountId,
+					filters: {
+						paginate: 'false'
+					}
+				},
+				success: function(data, status) {
+					// Parse callflows into displayable format
+					var formattedList = [];
+
+					_.each(data.data, function(callflow) {
+						var listNumbers = (callflow.numbers || '-').toString(),
+							isFeatureCode = callflow.featurecode !== false && !_.isEmpty(callflow.featurecode);
+
+						if(!isFeatureCode) {
+							if(callflow.name) {
+								callflow.description = listNumbers;
+								callflow.title = callflow.name;
+							} else {
+								callflow.title = listNumbers;
+							}
+
+							formattedList.push(callflow);
+						}
+					});
+
+					formattedList.sort(function(a, b) {
+						return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1;
+					});
+
+					callback && callback(formattedList);
+				}
+			});
+		},
+
 		accountGetData: function(globalCallback) {
 			var self = this;
 
@@ -96,6 +136,11 @@ define(function(require) {
 				},
 				noMatch: function(callback) {
 					self.accountGetNoMatch(function(data) {
+						callback && callback(null, data);
+					});
+				},
+				callflow: function(callback) {
+					self.accountGetCallflows(function(data) {
 						callback && callback(null, data);
 					});
 				},

--- a/src/apps/myaccount/views/account-layout.html
+++ b/src/apps/myaccount/views/account-layout.html
@@ -214,5 +214,52 @@
 				</div>
 			</div>
 		</li>
+
+		<!--Preflows-->
+		<li class="settings-item clearfix" data-name="account_preflow">
+			<a class="settings-link clearfix">
+				<span class="title">{{ i18n.account.preflowTitle }}</span>
+				<span class="description">
+				{{#if account.preflow.always}}
+					{{#each callflow}}
+						{{#compare ../account.preflow.always '===' this.id}} {{this.title}} {{/compare}}
+					{{/each}}
+				{{else}}
+					{{i18n.account.none}}
+				{{/if}}
+				</span>
+				<span class="update">
+					<i class="fa fa-cog fa-small"></i>
+					<span class="text">{{ i18n.editSettings }}</span>
+				</span>
+				<span class="changes-saved">{{ i18n.changesSaved }}</span>
+			</a>
+			<div class="settings-item-content">
+				<div class="row-fluid">
+					<div class="span12">
+						<form class="form-horizontal" id="form_account_preflow">
+							<div class="control-group">
+								<label class="control-label" for="account_preflow">{{ i18n.account.preflow }}</label>
+								<div class="controls">
+									<select id="account_preflow" name="preflow.always">
+										<option value="none">{{i18n.account.none}}</option>
+										{{#each callflow}}
+										<option value="{{this.id}}" {{#compare ../account.preflow.always '===' this.id}} selected{{/compare}}>{{this.title}}</option>
+										{{/each}}
+									</select>
+									<i class="help-popover fa fa-question-circle" data-original-title="{{i18n.account.preflowHelp}}" data-placement="right" data-toggle="tooltip"></i>
+								</div>
+							</div>
+							<div class="action-group clearfix">
+								<div class="action-bar">
+									<button type="button" class="monster-button cancel">{{ i18n.cancel }}</button>
+									<button type="submit" class="monster-button-success change" data-module="account" data-field="account_preflow">{{ i18n.saveChanges }}</button>
+								</div>
+							</div>
+						</form>
+					</div>
+				</div>
+			</div>
+		</li>
 	</ul>
 </div>


### PR DESCRIPTION
This would allow users to select an existing callflow as an account-level preflow through Monster UI.