### PR TITLE
Add capacity for filters to monster.request

### DIFF
--- a/src/js/lib/monster.js
+++ b/src/js/lib/monster.js
@@ -116,6 +116,15 @@ define(function(require) {
 
 			settings.url = options.apiUrl || settings.url;
 
+			if ('filters' in options.data) {
+				$.each(options.data.filters, function(filterKey, filterValue) {
+					var valueArray = [].concat(filterValue);
+					$.each(valueArray, function(key, value) {
+						settings.url += (settings.url.indexOf('?') > 0 ? '&' : '?') + filterKey + '=' + value;
+					});
+				});
+			}
+
 			settings.url += self._cacheString(settings);
 
 			var mappedKeys = [],

--- a/src/js/lib/monster.js
+++ b/src/js/lib/monster.js
@@ -116,7 +116,7 @@ define(function(require) {
 
 			settings.url = options.apiUrl || settings.url;
 
-			if ('filters' in options.data) {
+			if (options.data && 'filters' in options.data) {
 				$.each(options.data.filters, function(filterKey, filterValue) {
 					var valueArray = [].concat(filterValue);
 					$.each(valueArray, function(key, value) {


### PR DESCRIPTION
I would like to be able to use filters with custom API request definitions. This pull request adds the capacity for filters to monster.request() and achieves this in a similar way to how it is done in self.callApi().