### PR TITLE
Hide/show new account button via monster config

### DIFF
--- a/src/apps/common/submodules/accountBrowser/accountBrowser.js
+++ b/src/apps/common/submodules/accountBrowser/accountBrowser.js
@@ -37,7 +37,7 @@ define(function(require) {
 				dataTemplate = {
 					customClass: args.customClass || 'ab-sidebar',
 					hideRealm: hideRealm,
-					addAccountEnabled: (typeof onNewAccountClick === 'function')
+					addAccountEnabled: !monster.config.whitelabel.hideNewAccountCreation && (typeof onNewAccountClick === 'function')
 				},
 				layout = $(self.getTemplate({
 					name: 'layout',
@@ -108,9 +108,11 @@ define(function(require) {
 				e.stopPropagation();
 			});
 
-			template.find('.account-list-add').on('click', function() {
-				onNewAccountClick && onNewAccountClick();
-			});
+			if (!monster.config.whitelabel.hideNewAccountCreation) {
+				template.find('.account-list-add').on('click', function() {
+					onNewAccountClick && onNewAccountClick();
+				});
+			}
 
 			var findElemInData = function(searchString, data) {
 				var found = false;

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -86,7 +86,10 @@ define(function(require) {
 			//useDropdownApploader: true,
 
 			// The appstore is exposed to admins by default. If set to false, it will be hidden for all users.
-			// hideAppStore: true
+			// hideAppStore: true,
+
+			// If set to true, will hide creation of new accounts
+			// hideNewAccountCreation: true
 		},
 		developerFlags: {
 			// Setting this flag to true will show all restricted callflows in the Callflows app


### PR DESCRIPTION
It is not always desirable to expose account creation to users. This commit adds the option of hiding it via a new option in the whitelabel section of the monster config.