### PR TITLE
UI-3200: Switch address inputs

### DIFF
--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -827,8 +827,8 @@
 				},
 				"placeholder": {
 					"streetNumber": "Street Number",
-					"streetType": "Street Type",
 					"streetName": "Street Name",
+					"streetType": "Street Type",
 					"city": "City",
 					"state": "State",
 					"zip": "ZIP Code"

--- a/src/apps/common/submodules/portWizard/portWizard.js
+++ b/src/apps/common/submodules/portWizard/portWizard.js
@@ -560,12 +560,12 @@ define(function(require) {
 						minlength: 1,
 						maxlength: 8
 					},
-					'bill.street_type': {
+					'bill.street_address': {
 						required: true,
 						minlength: 1,
 						maxlength: 128
 					},
-					'bill.street_address': {
+                    'bill.street_type': {
 						required: true,
 						minlength: 1,
 						maxlength: 128

--- a/src/apps/common/submodules/portWizard/portWizard.js
+++ b/src/apps/common/submodules/portWizard/portWizard.js
@@ -565,7 +565,7 @@ define(function(require) {
 						minlength: 1,
 						maxlength: 128
 					},
-                    'bill.street_type': {
+					'bill.street_type': {
 						required: true,
 						minlength: 1,
 						maxlength: 128

--- a/src/apps/common/submodules/portWizard/views/accountVerification.html
+++ b/src/apps/common/submodules/portWizard/views/accountVerification.html
@@ -44,7 +44,7 @@
 					<input type="text" name="bill.street_number" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetNumber}}" value="{{request.bill.street_number}}">
 					<input type="text" name="bill.street_address" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetName}}" value="{{request.bill.street_address}}">
 					<input type="text" name="bill.street_type" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetType}}" value="{{request.bill.street_type}}">
-                    <input type="text" name="bill.locality" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.city}}" value="{{request.bill.locality}}">
+					<input type="text" name="bill.locality" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.city}}" value="{{request.bill.locality}}">
 					<input type="text" name="bill.region" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.state}}" value="{{request.bill.region}}">
 					<input type="text" name="bill.postal_code" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.zip}}" value="{{request.bill.postal_code}}">
 				</div>

--- a/src/apps/common/submodules/portWizard/views/accountVerification.html
+++ b/src/apps/common/submodules/portWizard/views/accountVerification.html
@@ -42,9 +42,9 @@
 				</label>
 				<div class="controls-list">
 					<input type="text" name="bill.street_number" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetNumber}}" value="{{request.bill.street_number}}">
-					<input type="text" name="bill.street_type" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetType}}" value="{{request.bill.street_type}}">
 					<input type="text" name="bill.street_address" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetName}}" value="{{request.bill.street_address}}">
-					<input type="text" name="bill.locality" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.city}}" value="{{request.bill.locality}}">
+					<input type="text" name="bill.street_type" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.streetType}}" value="{{request.bill.street_type}}">
+                    <input type="text" name="bill.locality" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.city}}" value="{{request.bill.locality}}">
 					<input type="text" name="bill.region" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.state}}" value="{{request.bill.region}}">
 					<input type="text" name="bill.postal_code" placeholder="{{i18n.portWizard.accountVerification.form.placeholder.zip}}" value="{{request.bill.postal_code}}">
 				</div>


### PR DESCRIPTION
At least in English, it's more natural to put the street name followed by the street type. An example of this is our office, "140 Geary St" (number->name->street type). When using the UI to submit a port request, the order felt unnatural and confused me for a second, so this PR addresses that.