### PR TITLE
UI-3313: Avoid getNumberFeatures() failure when number is mobile or is being ported

### DIFF
--- a/src/apps/common/submodules/numbers/numbers.js
+++ b/src/apps/common/submodules/numbers/numbers.js
@@ -26,6 +26,10 @@ define(function(require) {
 			var self = this;
 
 			_.each(arrayNumbers, function(number) {
+				if (number.state === 'port_in' || number.used_by === 'mobile') {
+					return;
+				}
+
 				var numberDiv = parent.find('[data-phonenumber="' + number.phoneNumber + '"]'),
 					args = {
 						target: numberDiv.find('.number-options'),

--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -1171,7 +1171,7 @@ define(function(require) {
 		if (!_.isPlainObject(number)) {
 			throw new TypeError('"number" is not an object');
 		}
-		if (!_.has(number, 'phoneNumber') || (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available'))) {
+		if (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available')) {
 			throw new Error('"number" does not represent a Kazoo phone number');
 		}
 		var numberFeatures = _.get(number, 'features_available', []);

--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -1171,7 +1171,7 @@ define(function(require) {
 		if (!_.isPlainObject(number)) {
 			throw new TypeError('"number" is not an object');
 		}
-		if (!_.has(number, 'phoneNumber') || (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available') && !_.has(number, 'features'))) {
+		if (!_.has(number, 'phoneNumber') || (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available'))) {
 			throw new Error('"number" does not represent a Kazoo phone number');
 		}
 		var numberFeatures = _.get(number, 'features_available', []);

--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -1171,7 +1171,7 @@ define(function(require) {
 		if (!_.isPlainObject(number)) {
 			throw new TypeError('"number" is not an object');
 		}
-		if (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available')) {
+		if (!_.has(number, 'phoneNumber') || (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available') && !_.has(number, 'features'))) {
 			throw new Error('"number" does not represent a Kazoo phone number');
 		}
 		var numberFeatures = _.get(number, 'features_available', []);


### PR DESCRIPTION
Numbers with `state === 'port_in'` or mobile numbers do not have the properties `features_available` nor `_read_only.features_available`. However, they both have the property `features`, so an extra check was added for this one.