### PR TITLE
OOB: Loosely check for Kazoo number feature  props

### DIFF
--- a/docs/monster-util/getNumberFeatures().md
+++ b/docs/monster-util/getNumberFeatures().md
@@ -10,14 +10,13 @@ monster.util.getNumberFeatures(number);
 ### Parameters
 Key | Description | Type | Default | Required
 :-: | --- | :-: | :-: | :-:
-`number` | A plain JavaScript object that represents a Kazoo phone number. | `Object`| | `true`
+`number` | A plain JavaScript object loosely representing a Kazoo phone number. | `Object`| | `true`
 
 ### Return value
-An `Array` that contains the list of feature codes that are available for the phone number.
+An `Array` that contains the list of feature codes that are available for the phone number. If no features are available, the array is empty.
 
 ### Errors
 * `"number" is not an object`: `number` is not a plain JavaScript object
-* `"number" does not represent a Kazoo phone number`: `number` does not have the expected feature properties for a Kazoo phone number object
 
 ## Description
 This method returns the features available of a specific phone number object.

--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -1156,14 +1156,10 @@ define(function(require) {
 		if (!_.isPlainObject(number)) {
 			throw new TypeError('"number" is not an object');
 		}
-		if (!_.has(number, 'features_available') && !_.has(number, '_read_only.features_available')) {
-			throw new Error('"number" does not represent a Kazoo phone number');
-		}
 		var numberFeatures = _.get(number, 'features_available', []);
-		if (_.isEmpty(numberFeatures)) {
-			numberFeatures = _.get(number, '_read_only.features_available', []);
-		}
-		return numberFeatures;
+		return _.isEmpty(numberFeatures)
+			? _.get(number, '_read_only.features_available', [])
+			: numberFeatures;
 	}
 
 	/**


### PR DESCRIPTION
The previous check was strictly enforcing `number` to be a Kazoo phone
number, meaning that objects without the required props would throw an
error.

This behavior is not backward compatible with current usage (PBX
Connector for example) and it would take too long to refacor those use
cases on an app by app basis.

THe solution it to loosely check for the props related to number feature
and return an empty array when missing/already empty.