### PR TITLE
UI-3139: Normalize path format for all platforms

### DIFF
--- a/gulp/helpers/helpers.js
+++ b/gulp/helpers/helpers.js
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'upath';
 import fs from 'fs';
 import parser from 'yargs-parser';
 import { src } from '../paths.js';
@@ -13,7 +13,7 @@ const getDirectories = pathToParse => fs
 
 export const env = parser(process.argv.slice(2));
 
-export const listAllApps = () => getDirectories(src + '/apps');
+export const listAllApps = () => getDirectories(join(src, 'apps'));
 
 export const getAppsToInclude = () => listAllApps()
 	.filter(app => !getAppsToExclude().includes(app));

--- a/gulp/paths.js
+++ b/gulp/paths.js
@@ -1,20 +1,21 @@
+import { join } from 'upath';
 import { dirname } from 'path';
 import { env } from './helpers/helpers.js';
 
-const pathToThisFile = __dirname;
+const pathToThisFile = dirname(__filename);
 const root = dirname(pathToThisFile);
-const distPath = root + '/dist/';
-const tmpPath = root + '/tmp';
-const requirePath = root + '/distRequired';
-const srcPath = root + '/src';
-const distDevPath = root + '/distDev';
-const appPath = env.app
-	? tmpPath + '/apps/' + env.app + '/'
-	: 'null';
+const dist = join(root, 'dist');
+const distDev = join(root, 'distDev');
+const require = join(root, 'distRequired');
+const src = join(root, 'src');
+const tmp = join(root, 'tmp');
+const app = env.app ? join(tmp, 'apps', env.app) : '';
 
-export const app = appPath;
-export const dist = distPath;
-export const distDev = distDevPath;
-export const require = requirePath;
-export const src = srcPath;
-export const tmp = tmpPath;
+export {
+	app,
+	dist,
+	distDev,
+	require,
+	src,
+	tmp
+};

--- a/gulp/paths.js
+++ b/gulp/paths.js
@@ -1,5 +1,4 @@
-import { join } from 'upath';
-import { dirname } from 'path';
+import { dirname, join } from 'upath';
 import { env } from './helpers/helpers.js';
 
 const pathToThisFile = dirname(__filename);

--- a/gulp/tasks/clean-move.js
+++ b/gulp/tasks/clean-move.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import del from 'del';
 import vinylPaths from 'vinyl-paths';
@@ -19,17 +20,17 @@ const cleanDistDev = () => gulp
 
 const moveBuiltFilesToDist = () => gulp
 	.src([
-		tmp + '/**/*',
-		'!' + tmp + '**/*.scss'
+		join(tmp, '**', '*'),
+		'!' + join(tmp, '**', '*.scss')
 	])
 	.pipe(gulp.dest(dist));
 
 const moveDistFilesToDev = () => gulp
-	.src(dist + '/**/*')
+	.src(join(dist, '**', '*'))
 	.pipe(gulp.dest(distDev));
 
 const moveSrcFilesToTmp = () => gulp
-	.src(src + '/**/*')
+	.src(join(src, '**', '*'))
 	.pipe(gulp.dest(tmp));
 
 

--- a/gulp/tasks/javascript.js
+++ b/gulp/tasks/javascript.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import uglify from 'gulp-uglify';
 import eslint from 'gulp-eslint';
@@ -13,17 +14,17 @@ const handleUglifyError = error => {
  */
 export const minifyJs = () => gulp
 	.src([
-		tmp + '/js/main.js',
-		tmp + '/js/templates.js'
+		join(tmp, 'js', 'main.js'),
+		join(tmp, 'js', 'templates.js')
 	])
 	.pipe(uglify().on('error', handleUglifyError))
-	.pipe(gulp.dest(tmp + '/js/'));
+	.pipe(gulp.dest(join(tmp, 'js')));
 
 /**
  * Minifies app.js
  */
 export const minifyJsApp = () => gulp
-	.src(app + 'app.js')
+	.src(join(app, 'app.js'))
 	.pipe(uglify().on('error', handleUglifyError))
 	.pipe(gulp.dest(app));
 
@@ -32,9 +33,9 @@ export const minifyJsApp = () => gulp
  */
 export const lint = () => gulp
 	.src([
-		src + '/**/*.js',
-		'!'+ src + '/js/vendor/**/*.js',
-		'!'+ src + '/js/lib/kazoo/dependencies/**/*.js'
+		join(src, '**', '*.js'),
+		'!' + join(src, 'js', 'vendor', '**', '*.js'),
+		'!' + join(src, 'js', 'lib', 'kazoo', 'dependencies', '**', '*.js')
 	])
 	.pipe(eslint())
 	.pipe(eslint.format());

--- a/gulp/tasks/require.js
+++ b/gulp/tasks/require.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import rjs from 'requirejs';
 import del from 'del';
@@ -86,8 +87,8 @@ const libsToExcludeFromApp = [
 const getConfigRequire = () => ({
 	dir: require, // direction
 	appDir: tmp, // origin
-	baseUrl:'./',
-	mainConfigFile: tmp + '/js/main.js',
+	baseUrl:'.',
+	mainConfigFile: join(tmp, 'js', 'main.js'),
 	fileExclusionRegExp: /^doc*|.*\.md|^\..*|^monster-ui\.build\.js$/,
 	findNestedDependencies:true,
 	preserveLicenseComments:false,
@@ -101,29 +102,29 @@ const getConfigRequire = () => ({
 	modules: env.hasOwnProperty('app')
 		? [
 			{
-				name:'js/main',
+				name: join('js', 'main'),
 				exclude: standardFilesToExclude
 			},
 			{
-				name: 'apps/' + env.app + '/app',
+				name: join('apps', env.app, 'app'),
 				exclude: libsToExcludeFromApp,
 				include: env.hasOwnProperty('pro')
-					? ['apps/' + env.app + '/submodules/pro/pro']
+					? [join('apps', env.app, 'submodules', 'pro',  'pro')]
 					: []
 			}
 		]
 		: [
 			{
-				name:'js/main',
+				name: join('js', 'main'),
 				exclude: [
 					...standardFilesToExclude,
 					...libsToExcludeFromWhole
 				],
 				include: getAppsToInclude().reduce((acc, item) => [
 					...acc,
-					'apps/' + item + '/app',
+					join('apps', item, 'app'),
 					...(getProApps().includes(item)
-						? ['apps/' + item + '/submodules/pro/pro']
+						? [join('apps', item, 'submodules', 'pro', 'pro')]
 						: [])
 				], [])
 			}
@@ -137,7 +138,7 @@ const buildRequire = done => {
 };
 
 const moveRequire = () => gulp
-	.src(require  + '/**/*')
+	.src(join(require , '**', '*'))
 	.pipe(gulp.dest(tmp));
 
 const cleanRequire = () => gulp

--- a/gulp/tasks/style.js
+++ b/gulp/tasks/style.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import sass from 'gulp-sass';
 import concatCss from 'gulp-concat-css';
@@ -9,9 +10,9 @@ const concatName = 'style.css';
 const cssDest = tmp + '/css/';
 const concatCssPaths = getAppsToInclude().reduce((acc, item) => [
 	...acc,
-	tmp + '/apps/' + item + '/style/*.css'
+	join(tmp, 'apps', item, 'style', '*.css')
 ], [
-	tmp + '/css/style.css'
+	join(tmp, 'css', 'style.css')
 ]);
 
 const concatAllCss = () => gulp
@@ -39,7 +40,7 @@ export const css = gulp.series(
  * Uglifies app.css
  */
 export const minifyCssApp = () => gulp
-	.src(app + '/style/app.css')
+	.src(join(app, 'style', 'app.css'))
 	.pipe(cleanCss())
 	.pipe(gulp.dest(app + 'style'));
 
@@ -47,6 +48,6 @@ export const minifyCssApp = () => gulp
  * Compiles all .scss files into .css and moves them to dist folder
  */
 export const compileSass = () => gulp
-	.src(tmp + '/**/*.scss')
+	.src(join(tmp, '**', '*.scss'))
 	.pipe(sass().on('error', sass.logError))
 	.pipe(gulp.dest(tmp));

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import handlebars from 'gulp-handlebars';
 import wrap from 'gulp-wrap';
@@ -15,18 +16,18 @@ const mode = env.app
 const pathsTemplates = {
 	whole: {
 		src: getAppsToInclude().reduce((acc, item) => acc.concat([
-			tmp + '/apps/' + item + '/views/*.html',
-			tmp + '/apps/' + item + 'submodules/*/views/*.html'
+			join(tmp, 'apps', item, 'views', '*.html'),
+			join(tmp, 'apps', item, 'submodules', '*', 'views', '*.html')
 		]), []),
-		dest: tmp + '/js/',
+		dest: join(tmp, 'js'),
 		concatName: 'templates-compiled.js'
 	},
 	app: {
 		src: [
-			app + 'views/*.html',
-			app + '/submodules/*/views/*.html'
+			join(app, 'views', '*.html'),
+			join(app, 'submodules', '*', 'views','*.html')
 		],
-		dest: app + 'views/',
+		dest: join(app, 'views'),
 		concatName: 'templates.js'
 	}
 };
@@ -65,8 +66,8 @@ const compileTemplates = () => gulp
 
 const concatTemplatesWhole = () => gulp
 	.src([
-		pathsTemplates.whole.dest + 'templates.js',
-		pathsTemplates.whole.dest + pathsTemplates.whole.concatName
+		join(pathsTemplates.whole.dest, 'templates.js'),
+		join(pathsTemplates.whole.dest, pathsTemplates.whole.concatName)
 	])
 	.pipe(concat('templates.js'))
 	.pipe(gulp.dest(pathsTemplates.whole.dest));
@@ -74,7 +75,7 @@ const concatTemplatesWhole = () => gulp
 const cleanTemplates = () => gulp
 	.src([
 		...pathsTemplates[mode].src,
-		pathsTemplates[mode].dest + pathsTemplates[mode].concatName
+		join(pathsTemplates[mode].dest, pathsTemplates[mode].concatName)
 	], {
 		read: false
 	})
@@ -106,8 +107,8 @@ export const templatesApp = gulp.series(
 	compileTemplates,
 	() => gulp
 		.src([
-			app + 'app.js',
-			pathsTemplates.app.dest + pathsTemplates.app.concatName
+			join(app, 'app.js'),
+			join(pathsTemplates.app.dest, pathsTemplates.app.concatName)
 		])
 		.pipe(concat('app.js'))
 		.pipe(gulp.dest(app)),

--- a/gulp/tasks/templates.js
+++ b/gulp/tasks/templates.js
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import { join, normalize, sep } from 'upath';
 import gulp from 'gulp';
 import handlebars from 'gulp-handlebars';
 import wrap from 'gulp-wrap';
@@ -6,7 +6,6 @@ import declare from 'gulp-declare';
 import concat from 'gulp-concat';
 import del from 'del';
 import vinylPaths from 'vinyl-paths';
-import { sep } from 'path';
 import { app, tmp } from '../paths.js';
 import { env, getAppsToInclude } from '../helpers/helpers.js';
 
@@ -42,7 +41,7 @@ const compileTemplates = () => gulp
 		namespace: 'monster.cache.templates',
 		noRedeclare: true,
 		processName: filePath => {
-			const splits = filePath.split(sep);
+			const splits = normalize(filePath).split(sep);
 			const indexSub = splits.indexOf('submodules');
 			let newName;
 			if (indexSub >= 0) {

--- a/gulp/tasks/watch-sources.js
+++ b/gulp/tasks/watch-sources.js
@@ -1,9 +1,10 @@
+import { join, normalize } from 'upath';
 import browserSync from 'browser-sync';
 import del from 'del';
 import gulp from 'gulp';
 import cache from 'gulp-cached';
 import sass from 'gulp-sass';
-import path from 'path';
+import { relative, resolve } from 'path';
 import { src, dist } from '../paths.js';
 
 /**
@@ -21,7 +22,7 @@ const buildWatchPipeline = args => {
 		useCache = !!args.useCache,
 		reload = !!args.reload,
 		server = args.server,
-		pipeline = gulp.src(`${src}/**/*.${fileExt}`);
+		pipeline = gulp.src(join(src, '**', `*.${fileExt}`));
 
 	if (process) {
 		pipeline = pipeline.pipe(process);
@@ -93,25 +94,25 @@ const getWatchJsonFn = server =>
 
 const getUnlinkFileFn = server =>
 	filePath => {
-		var filePathFromSrc = path.relative(path.resolve(src), filePath),
-			destFilePath = path.resolve(dist, filePathFromSrc);
+		var filePathFromSrc = relative(resolve(src), filePath),
+			destFilePath = resolve(dist, filePathFromSrc);
 
 		if (filePath.endsWith('.scss')) {
 			destFilePath = destFilePath.replace(/\.scss$/, ".css");
 		}
 
-		del.sync(destFilePath);
+		del.sync(normalize(destFilePath));
 
 		server.reload();
 	};
 
 const watchSources = server => {
 	let watchers = [
-		gulp.watch(src + '/**/*.scss', getWatchSassFn(server)),
-		gulp.watch(src + '/**/*.css', getWatchCssFn(server)),
-		gulp.watch(src + '/**/*.js', getWatchJsFn(server)),
-		gulp.watch(src + '/**/*.html', getWatchHtmlFn(server)),
-		gulp.watch(src + '/**/*.json', getWatchJsonFn(server))
+		gulp.watch(join(src, '**', '*.scss'), getWatchSassFn(server)),
+		gulp.watch(join(src, '**', '*.css'), getWatchCssFn(server)),
+		gulp.watch(join(src, '**', '*.js'), getWatchJsFn(server)),
+		gulp.watch(join(src, '**', '*.html'), getWatchHtmlFn(server)),
+		gulp.watch(join(src, '**', '*.json'), getWatchJsonFn(server))
 	];
 
 	// Handle delete file events

--- a/gulp/tasks/watch-sources.js
+++ b/gulp/tasks/watch-sources.js
@@ -1,10 +1,9 @@
-import { join, normalize } from 'upath';
+import { join, normalize, relative, resolve } from 'upath';
 import browserSync from 'browser-sync';
 import del from 'del';
 import gulp from 'gulp';
 import cache from 'gulp-cached';
 import sass from 'gulp-sass';
-import { relative, resolve } from 'path';
 import { src, dist } from '../paths.js';
 
 /**
@@ -94,14 +93,14 @@ const getWatchJsonFn = server =>
 
 const getUnlinkFileFn = server =>
 	filePath => {
-		var filePathFromSrc = relative(resolve(src), filePath),
-			destFilePath = resolve(dist, filePathFromSrc);
+		const filePathFromSrc = relative(resolve(src), normalize(filePath));
+		let destFilePath = resolve(dist, filePathFromSrc);
 
 		if (filePath.endsWith('.scss')) {
 			destFilePath = destFilePath.replace(/\.scss$/, ".css");
 		}
 
-		del.sync(normalize(destFilePath));
+		del.sync(destFilePath);
 
 		server.reload();
 	};

--- a/gulp/tasks/write-config.js
+++ b/gulp/tasks/write-config.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import fs from 'fs';
 import { app, tmp } from '../paths.js';
@@ -18,7 +19,7 @@ const writeBulkAppsConfig = () => {
 	let content;
 
 	listAllApps().forEach(item => {
-		fileName = tmp + '/apps/' + item + '/app-build-config.json';
+		fileName = join(tmp, 'apps', item, 'app-build-config.json');
 		content = {
 			version: getProApps().includes(item)
 				? 'pro'
@@ -33,7 +34,7 @@ const writeBulkAppsConfig = () => {
  * doesn't reload the assets
  */
 export const writeConfigProd = () => {
-	const mainFileName = tmp + '/build-config.json';
+	const mainFileName = join(tmp, 'build-config.json');
 	const content = {
 		type: 'production',
 		preloadApps: getAppsToInclude()
@@ -44,7 +45,7 @@ export const writeConfigProd = () => {
 };
 
 export const writeConfigDev = () => {
-	const fileName = tmp + '/build-config.json';
+	const fileName = join(tmp, 'build-config.json');
 	const content = {
 		version: env.pro
 			? 'pro'
@@ -58,7 +59,7 @@ export const writeConfigDev = () => {
  * Add flags if needed, like pro/lite version
  */
 export const writeConfigApp = () => {
-	const fileName = app + 'app-build-config.json';
+	const fileName = join(app, 'app-build-config.json');
 	const content = {
 		version: env.pro
 			? 'pro'

--- a/gulp/tasks/write-version.js
+++ b/gulp/tasks/write-version.js
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import gulp from 'gulp';
 import { writeFileSync } from 'fs';
 import { tmp } from '../paths';
@@ -7,7 +8,7 @@ import { version } from '../../package.json';
  * Writes version file to display in monster
  */
 const writeVersion = () => {
-	const fileName = tmp + '/VERSION';
+	const fileName = join(tmp, 'VERSION');
 	writeFileSync(fileName, version);
 	return gulp.src(fileName);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3315,7 +3315,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3336,12 +3337,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3356,17 +3359,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3483,7 +3489,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3495,6 +3502,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3509,6 +3517,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3516,12 +3525,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3540,6 +3551,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3620,7 +3632,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3632,6 +3645,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3717,7 +3731,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3753,6 +3768,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3772,6 +3788,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3815,12 +3832,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8735,9 +8754,9 @@
       }
     },
     "upath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "handlebars": "^4.0.11",
     "requirejs": "^2.3.5",
     "semver": "^5.6.0",
+    "upath": "^1.1.2",
     "vinyl-paths": "^2.1.0",
     "yargs-parser": "^10.1.0"
   }


### PR DESCRIPTION
Format all paths in unix style (backslash) since it is supported by all
platforms.

requirejs and chokidar (used by gulp.watch) expects unix formatted paths
and silently fails when a Windows path is provided.

This change impacts the whole build system and will hopfully avoid path
related error later on.