### PR TITLE
MCCP-22: Remove unused/deprecated APIs

### DIFF
--- a/src/js/lib/jquery.kazoosdk.js
+++ b/src/js/lib/jquery.kazoosdk.js
@@ -367,13 +367,6 @@
 				'update': { verb: 'POST', url: 'accounts/{accountId}/qubicle_skills/{skillId}' },
 				'create': { verb: 'PUT', url: 'accounts/{accountId}/qubicle_skills' }
 			},
-			qubicleSkillRules: {
-				'delete': { verb: 'DELETE', url: 'accounts/{accountId}/qubicle_skill_rules/{ruleId}' },
-				'list': { verb: 'GET', url: 'accounts/{accountId}/qubicle_skill_rules' },
-				'patch': { verb: 'PATCH', url: 'accounts/{accountId}/qubicle_skill_rules/{ruleId}' },
-				'update': { verb: 'POST', url: 'accounts/{accountId}/qubicle_skill_rules/{ruleId}' },
-				'create': { verb: 'PUT', url: 'accounts/{accountId}/qubicle_skill_rules' }
-			},
 			recordings: {
 				'get': { verb: 'GET', url: 'accounts/{accountId}/recordings/{recordingId}' },
 				'delete': { verb: 'DELETE', url: 'accounts/{accountId}/recordings/{resourceId}' },


### PR DESCRIPTION
There APIs are not longer needed for call center pro so they have been removed