### PR TITLE
UI-3377: Remove stop-gap fixing overly long dialog handling

### DIFF
--- a/src/apps/myaccount/submodules/balance/balance.js
+++ b/src/apps/myaccount/submodules/balance/balance.js
@@ -328,9 +328,6 @@ define(function(require) {
 				monster.pub('myaccount.updateMenu', dataUpdate);
 
 				popup = monster.ui.dialog(addCreditDialog, {
-					draggable: false,
-					position: ['center', 24],
-					maxHeight: $(window).height() - 48,
 					title: self.i18n.active().balance.addCreditDialogTitle
 				});
 


### PR DESCRIPTION
This stop-gap is not required after #342 was merged.