### PR TITLE
MUI-33: Add source maps to gulp build process

### DIFF
--- a/gulp/tasks/javascript.js
+++ b/gulp/tasks/javascript.js
@@ -3,6 +3,7 @@ import { join } from 'upath';
 import gulp from 'gulp';
 import uglify from 'gulp-uglify';
 import eslint from 'gulp-eslint';
+import sourcemaps from 'gulp-sourcemaps';
 import { app, src, tmp } from '../paths.js';
 
 const config = {
@@ -35,7 +36,9 @@ export const minifyJs = () => gulp
 		join(tmp, 'js', 'main.js'),
 		join(tmp, 'js', 'templates.js')
 	])
+	.pipe(sourcemaps.init())
 	.pipe(uglify().on('error', handleUglifyError))
+	.pipe(sourcemaps.write('.', { sourceRoot: '/' }))
 	.pipe(gulp.dest(join(tmp, 'js')));
 
 /**

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-handlebars": "^5.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^4.0.1",
+    "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^2.1.2",
     "gulp-wrap": "^0.14.0",
     "requirejs": "^2.3.5",


### PR DESCRIPTION
We've added source maps recently to help us debug errors recorded via Sentry. We think source maps could be useful for Monster so I have created a PR.