### PR TITLE
MSTR-33: Prevent to disable scroll on error

### DIFF
--- a/src/apps/common/submodules/portWizard/portWizard.js
+++ b/src/apps/common/submodules/portWizard/portWizard.js
@@ -1781,7 +1781,8 @@ define(function(require) {
 			self.callApi({
 				resource: 'port.changeState',
 				data: _.merge({
-					accountId: self.portWizardGet('accountId')
+					accountId: self.portWizardGet('accountId'),
+					generateError: false
 				}, args.data),
 				success: function(data, status) {
 					args.hasOwnProperty('success') && args.success(data.data);


### PR DESCRIPTION
This change is to not generate the default error on port state change. The errors are handled within the error callback. If the `callApi` function is left to handle the errors, it shows a dialog with the error details in an asynchronous way. This process is stopped abruptly because the wizard is rendered again, which in turn causes that the error dialog is not displayed, but the page body's scroll is disabled as if it was shown.