### PR TITLE
MSTR-74: Lowercase username on login

### DIFF
--- a/src/apps/auth/app.js
+++ b/src/apps/auth/app.js
@@ -1066,7 +1066,7 @@ define(function(require) {
 
 		loginClick: function(data) {
 			var self = this,
-				loginUsername = $('#login').val(),
+				loginUsername = $('#login').val().toLowerCase(),
 				loginPassword = $('#password').val(),
 				loginAccountName = $('#account_name').val(),
 				hashedCreds = monster.md5(loginUsername + ':' + loginPassword),


### PR DESCRIPTION
Since the username is normalized to lowercase when a user is created in Kazoo `cb_users`, it should also be possible to authenticate with any case.