### PR TITLE
MSTR-78: Scroll through popup rather than body when selecting models

### DIFF
--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -233,7 +233,9 @@ define(function(require) {
 							submodule: 'chooseModel'
 						}));
 				templateDevice.find('.block-footer').slideDown(function() {
-					$('html, body').animate({ scrollTop: templateDevice.find('div.block-device-info div.title-bar').offset().top }, function() {
+					popup.animate({
+						scrollTop: popup.offset().top
+					}, 250, function() {
 						templateDevice.find('#name').focus();
 					});
 				});

--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -234,7 +234,7 @@ define(function(require) {
 						}));
 				templateDevice.find('.block-footer').slideDown(function() {
 					popup.animate({
-						scrollTop: popup.offset().top
+						scrollTop: popup.find('.block-device-info').offset().top
 					}, 250, function() {
 						templateDevice.find('#name').focus();
 					});


### PR DESCRIPTION
Following the behaavioral update of dialogs, scrolling on the body was
disabled when a dialog is open.

Here we had to update the scrolling target when a model is selected
since the original one was body and could break the UX.