### PR TITLE
OOB: Handle PyYAML yaml.load(input) deprecation

### DIFF
--- a/scripts/validate_mkdocs.py
+++ b/scripts/validate_mkdocs.py
@@ -34,7 +34,7 @@ def parse_page(errors_detected, page):
         return errors_detected
 
 stream = open("docs/mkdocs/mkdocs.yml", 'r')
-mkdocs = yaml.load_all(stream)
+mkdocs = yaml.load_all(stream, Loader=yaml.SafeLoader)
 errors_detected = False
 
 for doc in mkdocs:


### PR DESCRIPTION
The following warning was thrown on CI build:
> ./scripts/validate_mkdocs.py:40: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

Following the deprecation guide, this update simply specifies a `Loader=` parameter when loading the mkdoc toc.