### PR TITLE
Fix monster.util.friendlyTimer (corrected)

### DIFF
--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -259,9 +259,9 @@ define(function(require) {
 			return isReseller;
 		},
 
-		/****************** Helpers not documented because people shoudln't need to use them *******************/
+		/****************** Helpers not documented because people shouldn't need to use them *******************/
 
-		// Helper only used in conference app, takes seconds and transforms it into a timer
+		// Takes seconds and transforms it into a timer
 		friendlyTimer: function(pSeconds, pMode) {
 			var mode = pMode || 'normal',
 				seconds = Math.floor(pSeconds),
@@ -298,7 +298,7 @@ define(function(require) {
 			} else {
 				displayTime = format2Digits(minutes) + ':' + format2Digits(remainingSeconds);
 
-				if (hours) {
+				if (hours || days) {
 					displayTime = format2Digits(hours) + ':' + displayTime;
 				}
 


### PR DESCRIPTION
Hi @azefiel ,

Sorry about that in #500 , I tried updating my branch to master by issueing a pull request to myself...
Fixed that up now with a rebase and a fresh branch.

Previous description:
Fix issue where friendlyTimer did not display hours where hours = 0, but days > 0.

Correct spelling "shoudln't" > "shouldn't".
Adjust inline comment, as timer is now used in other places as well (cdrs app / Handlebars...)