### PR TITLE
[4.0] Fix monster.util.friendlyTimer hours formatting

### DIFF
--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -484,9 +484,9 @@ define(function(require){
 			return key ? vars[key] : vars;
 		},
 
-		/****************** Helpers not documented because people shoudln't need to use them *******************/
+		/****************** Helpers not documented because people shouldn't need to use them *******************/
 
-		// Helper only used in conference app, takes seconds and transforms it into a timer
+		// Takes seconds and transforms it into a timer
 		friendlyTimer: function(pSeconds, pMode) {
 			var mode = pMode || 'normal',
 				seconds = Math.floor(pSeconds),
@@ -509,7 +509,7 @@ define(function(require){
 			else {
 				displayTime = format2Digits(minutes) + ':' + format2Digits(remainingSeconds);
 
-				if (hours) {
+				if (hours || days) {
 					displayTime = format2Digits(hours) + ':' + displayTime;
 				}
 


### PR DESCRIPTION
Fix issue where friendlyTimer did not display hours where hours = 0, but days > 0.

Correct spelling "shoudln't" > "shouldn't".
Adjust inline comment, as timer is now used in other places as well (cdrs app / Handlebars...)