### PR TITLE
KZOO-16: Fix port_authority property reading from port_request object

### DIFF
--- a/src/apps/common/submodules/portListing/portListing.js
+++ b/src/apps/common/submodules/portListing/portListing.js
@@ -312,7 +312,7 @@ define(function(require) {
 							_.get(portRequest, 'numbers')
 						),
 						unactionableStatuses = ['canceled', 'completed'],
-						isAgent = self.portListingUtilIsAgent(_.get(portRequest, 'port_authority')),
+						isAgent = self.portListingUtilIsAgent(_.get(portRequest, '_read_only.port_authority')),
 						isUpdateable = !_.includes(unactionableStatuses, portRequest.port_state);
 
 					return _.merge({


### PR DESCRIPTION
Right now even if the account you are currently logged in is the port authority for a given port request the UI doesn't show the `action_required` nor the `private` options when you try to create a comment on that port request, this change fixes that.