### PR TITLE
MSTR-119: Allow link labels to wrap inside their container

### DIFF
--- a/src/apps/common/submodules/numberSelector/numberSelector.scss
+++ b/src/apps/common/submodules/numberSelector/numberSelector.scss
@@ -52,7 +52,7 @@
 }
 .number-selector .number-selector-dropdown .number-selector-element {
 	display: none;
-	height: 30px;
+	min-height: 30px;
 	line-height: 30px;
 	padding: 0px 10px;
 	background: #fff;


### PR DESCRIPTION
Fixes link labels wrapping off their container on number entity selection.

![image013](https://user-images.githubusercontent.com/1958193/71386830-4f63e600-25a5-11ea-80ef-97938ea05420.png)