### PR TITLE
[4.3] MSTR-127: Add notEqualTo custom validation rule

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -87,10 +87,18 @@ We added the following custom rules to the set of usable validation rules:
 
 * _checkList_: The value of this element should not appear in the provided list (array or map).
 * _greaterDate_: The element should contain a date greater than the one in the provided input.
+* _greaterThan_: The element should contain a number greater than or equal to the one in the provided input.
+* _hexadecimal_: The element should contain a valid hexadecimal value.
 * _ipv4_: The element should contain a valid IPv4 address.
+* _lowerThan_: The element should contain a number lower than or equal to the one in the provided input.
 * _mac_: The element should contain a valid MAC address.
+* _notEqualTo_: The element should not contain a value equal to any in the provided inputs.
+* _phoneNumber_: The element should contain a valid phoneNumber.
+* _protocol_: The element should contain a valid protocol prefix.
 * _realm_: The element should contain a valid realm.
+* _regex_: The element should contain a value that matches the provided regular expression.
 * _time12h_: The element should contain a time in 12-hour format (AM/PM).
+* _time24h_: The element should contain a time in 24-hour format.
 
 We didn't make a simplified function to add custom rules directly within your app, but you can do it using the [_jQuery.validator.addMethod_][add_method] method.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -85,12 +85,12 @@ For the full list of standard validation rules, see [here][validation_methods].
 
 We added the following custom rules to the set of usable validation rules:
 
-*	_checkList_: The value of this element should not appear in the provided list (array or map).
-*	_greaterDate_: The element should contain a date greater than the one in the provided input.
-*	_ipv4_: The element should contain a valid IPv4 address.
-*	_mac_: The element should contain a valid MAC address.
-*	_realm_: The element should contain a valid realm.
-*	_time12h_: The element should contain a time in 12-hour format (AM/PM).
+* _checkList_: The value of this element should not appear in the provided list (array or map).
+* _greaterDate_: The element should contain a date greater than the one in the provided input.
+* _ipv4_: The element should contain a valid IPv4 address.
+* _mac_: The element should contain a valid MAC address.
+* _realm_: The element should contain a valid realm.
+* _time12h_: The element should contain a time in 12-hour format (AM/PM).
 
 We didn't make a simplified function to add custom rules directly within your app, but you can do it using the [_jQuery.validator.addMethod_][add_method] method.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -85,12 +85,12 @@ For the full list of standard validation rules, see [here][validation_methods].
 
 We added the following custom rules to the set of usable validation rules:
 
-*	_mac_: The element should contain a valid MAC address.
-*	_ipv4_: The element should contain a valid IPv4 address.
-*	_time12h_: The element should contain a time in 12-hour format (AM/PM).
-*	_realm_: The element should contain a valid realm.
-*	_greaterDate_: The element should contain a date greater than the on in the provided input.
 *	_checkList_: The value of this element should not appear in the provided list (array or map).
+*	_greaterDate_: The element should contain a date greater than the one in the provided input.
+*	_ipv4_: The element should contain a valid IPv4 address.
+*	_mac_: The element should contain a valid MAC address.
+*	_realm_: The element should contain a valid realm.
+*	_time12h_: The element should contain a time in 12-hour format (AM/PM).
 
 We didn't make a simplified function to add custom rules directly within your app, but you can do it using the [_jQuery.validator.addMethod_][add_method] method.
 

--- a/src/apps/core/i18n/en-US.json
+++ b/src/apps/core/i18n/en-US.json
@@ -171,7 +171,8 @@
 			"time24h": "Please enter a valid time in 24-hour format.",
 			"__comment": "UI-2654: add protocol rule",
 			"__version": "v4.1",
-			"protocol": "Please include the \"://\" characters."
+			"protocol": "Please include the \"://\" characters.",
+			"notEqualTo": "The value should be unique."
 		},
 		"required": "Required."
 	},

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -1373,6 +1373,17 @@ define(function(require) {
 				return this.optional(element) || isLinkedFieldEmptyOrHidden || isValid;
 			}, localization.customRules.greaterThan);
 
+			$.validator.addMethod('notEqualTo', function(value, element, param) {
+				var $compElements = param instanceof jQuery ? param : $(param),
+					$compElementsToCheck = $compElements.filter(':visible').not(element),
+					$equalElements = $compElementsToCheck.filter(function() {
+						return $(this).val() === value;
+					}),
+					isValid = $equalElements.length === 0;
+
+				return this.optional(element) || isValid;
+			}, localization.customRules.notEqualTo);
+
 			this.customValidationInitialized = true;
 		},
 


### PR DESCRIPTION
This is a new custom rule for the jQuery validation plugin, to check that a form field’s value does not match one or more of other field’s values.