### PR TITLE
[4.3] MSTR-108: Trigger myaccount onOpen callback when container transition ended

### DIFF
--- a/src/apps/myaccount/app.js
+++ b/src/apps/myaccount/app.js
@@ -471,9 +471,11 @@ define(function(require) {
 								self.displayUserSection();
 
 								myaccount.addClass('myaccount-open');
-								setTimeout(function() { $('#monster_content').hide(); }, 300);
 
-								callback && callback();
+								myaccount.one('transitionend', function() {
+									$('#monster_content').hide();
+									callback && callback();
+								});
 							}
 						};
 


### PR DESCRIPTION
Previously, the onOpen callback was triggered as soon as the
`myaccount-open` class was added to myaccount's container.

Since a transition animating the height of the container was tied to
`myaccount-open` class, it means the container only reached its full
size once the transition ended.

That behavior became problematic when the onOpen callback created a
dialog, as that dialog's container would be set to myaccount's
container. Because the onOpen callback was triggered near the same time
than when the transition started, the dialog would be positioned based
on myaccount's container current height, which would be close to 0.

Now the onOpen callback it triggered once the transition ends and
myaccount's container is fully visible.