### PR TITLE
Create utility to retrieve capability information

### DIFF
--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -72,6 +72,7 @@ pages:
     - 'docs/monster-util/formatVariableToDisplay().md'
     - 'docs/monster-util/getBookkeepers().md'
     - 'docs/monster-util/getBusinessDate().md'
+    - 'docs/monster-util/getCapability().md'
     - 'docs/monster-util/getCurrencySymbol().md'
     - 'docs/monster-util/getCurrentTimeZone().md'
     - 'docs/monster-util/getUrlVars().md'

--- a/docs/monster-util/getCapability().md
+++ b/docs/monster-util/getCapability().md
@@ -1,0 +1,62 @@
+title: getCapability()
+
+# monster.util.getCapability()
+
+## Syntax
+```javascript
+monster.util.getCapability(path);
+```
+
+### Parameters
+Key | Description | Type | Default | Required
+:-: | --- | :-: | :-: | :-:
+`path` | Path to a resource/feature to access. | `String|String[]` | | `true`
+
+### Return value
+
+- An `Object` literal describing the capability of a feature
+
+Key | Description | Type
+:-: | --- | :-:
+`isEnabled` | Whether the feature at `path` is available. | `Boolean`
+`defaultValue` | Default value for capability at `path`. | `Boolean`
+
+- An `Array` listing features when `path` only contains a resource
+- `undefined` when `path` cannot be resolved into a valid feature
+
+## Description
+The `monster.util.getCapability` method returns data informing on the capability of a feature for a resource.
+
+The data returned is cluster specific, meaning the user/account logged in does not impact the state of capabilities returned.
+
+That said, when no user is logged-in, valid resource/feature will return `undefined` as the capabilities information is only shared by Kazoo on successful authentication.
+
+## Examples
+
+### Access a resource/feature
+```js
+console.log(monster.util.getCapability('voicemail.transcription'));
+// -> { "isEnabled": true, "defaultValue": false }
+```
+
+### List features for a resource
+```js
+console.log(monster.util.getCapability('voicemail'));
+// -> ["transcription"]
+```
+
+### Access an invalid resource/feature path
+```js
+console.log(monster.util.getCapability('voicemail.transcription.default'));
+// -> undefined
+
+console.log(monster.util.getCapability('voicemail.superman'));
+// -> undefined
+
+console.log(monster.util.getCapability('user'));
+// -> undefined
+
+console.log(monster.util.getCapability('user.superman'));
+// -> undefined
+```
+

--- a/src/apps/auth/app.js
+++ b/src/apps/auth/app.js
@@ -28,6 +28,17 @@ define(function(require) {
 			kazooConnectionName: 'kazooAPI',
 			mainContainer: undefined,
 			isAuthentified: false,
+
+			/**
+			 * Holds map of capababilities returned on authentication.
+			 * @type {Object}
+			 *
+			 * Set once authentication is successful.
+			 *
+			 * This map does not need to be refreshed as capabilities are set on a per cluster basis
+			 * and not per account.
+			 */
+			capabilities: {},
 			connections: {}
 		},
 
@@ -265,6 +276,8 @@ define(function(require) {
 			self.resellerId = data.data.reseller_id;
 
 			self.appFlags.isAuthentified = true;
+
+			_.set(self.appFlags, 'capabilities', _.get(data.data, 'capabilities', {}));
 
 			self.appFlags.connections[self.appFlags.kazooConnectionName] = {
 				accountId: data.data.account_id,

--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -1013,6 +1013,29 @@ define(function(require) {
 	util.getBookkeepers = getBookkeepers;
 
 	/**
+	 * Returns capability information about a resource/feature.
+	 * @param  {String|String[]} path Path to resource/feature.
+	 * @return {undefined|String[]|Object} Capability information.
+	 */
+	function getCapability(path) {
+		var node = _.get(monster.apps.auth.appFlags.capabilities, path);
+		var isFeatureNode = _.has(node, 'available');
+
+		if (!_.isPlainObject(node)) {
+			return undefined;
+		}
+		if (!isFeatureNode) {
+			return _.keys(node);
+		}
+		return _.merge({
+			isEnabled: _.get(node, 'available')
+		}, _.has(node, 'default') ? {
+			defaultValue: _.get(node, 'default')
+		} : {});
+	}
+	util.getCapability = getCapability;
+
+	/**
 	 * Return the symbol of the currency used through the UI
 	 * @return {String} Symbol of currency
 	 */


### PR DESCRIPTION
The goal of this PR is to abstract capability information resolving by exposing a utility method giving easy access to such data (made available by https://github.com/2600hz/kazoo/pull/6342)

Developers are expected to access capability information like follows:
```js
monster.util.getCapability('voicemail.transcription');
// -> { isEnabled: true, defaultValue: false }
```

For more information, check out the documentation entry about this helper.