### PR TITLE
[4.3] MPRO-7: For Polycom Models, Prefix VVX in front of all VVX model names in Monster UI

### DIFF
--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -41,6 +41,7 @@ define(function(require) {
 				families,
 				models,
 				prefix = ['vvx'];
+				
 			_.each(data, function(brand, brandKey) {
 				families = [];
 
@@ -48,17 +49,10 @@ define(function(require) {
 					models = [];
 
 					_.each(family.models, function(model, modelKey) {
-						if ( prefix.includes(family.name) ) {
-							models.push({
-								id: modelKey.toLowerCase(),
-								name: _.toUpper(family.name) + " " + model.name
-							});
-						} else {
-							models.push({
-								id: modelKey.toLowerCase(),
-								name: model.name
-							});
-						}
+						models.push({
+							id: modelKey.toLowerCase(),
+							name: prefix.includes(family.name) ? _.toUpper(family.name) + " " + model.name : model.name
+						});
 					});
 
 					families.push({

--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -39,8 +39,8 @@ define(function(require) {
 					brands: []
 				},
 				families,
-				models;
-
+				models,
+				prefix = ['vvx'];
 			_.each(data, function(brand, brandKey) {
 				families = [];
 
@@ -48,10 +48,17 @@ define(function(require) {
 					models = [];
 
 					_.each(family.models, function(model, modelKey) {
-						models.push({
-							id: modelKey.toLowerCase(),
-							name: model.name
-						});
+						if ( prefix.includes(family.name) ) {
+							models.push({
+								id: modelKey.toLowerCase(),
+								name: _.toUpper(family.name) + " " + model.name
+							});
+						} else {
+							models.push({
+								id: modelKey.toLowerCase(),
+								name: model.name
+							});
+						}
 					});
 
 					families.push({

--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -47,7 +47,18 @@ define(function(require) {
 		},
 
 		chooseModelFormatProvisionerData: function(data) {
-			var self = this;
+			var self = this,
+				resolveModelName = function resolveModelName(familyName, modelName) {
+					return _
+						.chain(self.appFlags.chooseModel.familyNamesAsPrefix)
+						.filter(function(name) {
+							return name === familyName;
+						})
+						.map(_.toUpper)
+						.concat([modelName])
+						.join(' ')
+						.value();
+				};
 
 			return {
 				brands: _.map(data, function(brand, brandKey) {
@@ -61,9 +72,7 @@ define(function(require) {
 								models: _.map(family.models, function(model, modelKey) {
 									return {
 										id: _.toLower(modelKey),
-										name: _.includes(self.appFlags.chooseModel.familyNamesAsPrefix, family)
-											? _.toUpper(family) + ' ' + model
-											: model
+										name: resolveModelName(family.name, model.name)
 									};
 								})
 							};

--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -18,6 +18,18 @@ define(function(require) {
 			'common.chooseModel.render': 'chooseModelRender'
 		},
 
+		appFlags: {
+			chooseModel: {
+				/**
+				 * Family names for which model names should be prefixed by its family name
+				 * @type {Array}
+				 */
+				familyNamesAsPrefix: [
+					'vvx'
+				]
+			}
+		},
+
 		chooseModelRender: function(args) {
 			var self = this;
 
@@ -35,7 +47,7 @@ define(function(require) {
 		},
 
 		chooseModelFormatProvisionerData: function(data) {
-			var familiesAsPrefix = ['vvx'];
+			var self = this;
 
 			return {
 				brands: _.map(data, function(brand, brandKey) {
@@ -49,7 +61,7 @@ define(function(require) {
 								models: _.map(family.models, function(model, modelKey) {
 									return {
 										id: _.toLower(modelKey),
-										name: _.includes(familiesAsPrefix, family)
+										name: _.includes(self.appFlags.chooseModel.familyNamesAsPrefix, family)
 											? _.toUpper(family) + ' ' + model
 											: model
 									};

--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -35,41 +35,30 @@ define(function(require) {
 		},
 
 		chooseModelFormatProvisionerData: function(data) {
-			var formattedData = {
-					brands: []
-				},
-				families,
-				models,
-				prefix = ['vvx'];
+			var familiesAsPrefix = ['vvx'];
 
-			_.each(data, function(brand, brandKey) {
-				families = [];
-
-				_.each(brand.families, function(family, familyKey) {
-					models = [];
-
-					_.each(family.models, function(model, modelKey) {
-						models.push({
-							id: modelKey.toLowerCase(),
-							name: prefix.includes(family.name) ? _.toUpper(family.name) + ' ' + model.name : model.name
-						});
-					});
-
-					families.push({
-						id: familyKey.toLowerCase(),
-						name: family.name,
-						models: models
-					});
-				});
-
-				formattedData.brands.push({
-					id: brandKey.toLowerCase(),
-					name: brand.name,
-					families: families
-				});
-			});
-
-			return formattedData;
+			return {
+				brands: _.map(data, function(brand, brandKey) {
+					return {
+						id: _.lowerCase(brandKey),
+						name: brand.name,
+						families: _.map(brand.families, function(family, familyKey) {
+							return {
+								id: _.toLower(familyKey),
+								name: family.name,
+								models: _.map(family.models, function(model, modelKey) {
+									return {
+										id: _.toLower(modelKey),
+										name: _.includes(familiesAsPrefix, family)
+											? _.toUpper(family) + ' ' + model
+											: model
+									};
+								})
+							};
+						})
+					};
+				})
+			};
 		},
 
 		hideDeviceFooter: function(templateDevice) {

--- a/src/apps/common/submodules/chooseModel/chooseModel.js
+++ b/src/apps/common/submodules/chooseModel/chooseModel.js
@@ -41,7 +41,7 @@ define(function(require) {
 				families,
 				models,
 				prefix = ['vvx'];
-				
+
 			_.each(data, function(brand, brandKey) {
 				families = [];
 
@@ -51,7 +51,7 @@ define(function(require) {
 					_.each(family.models, function(model, modelKey) {
 						models.push({
 							id: modelKey.toLowerCase(),
-							name: prefix.includes(family.name) ? _.toUpper(family.name) + " " + model.name : model.name
+							name: prefix.includes(family.name) ? _.toUpper(family.name) + ' ' + model.name : model.name
 						});
 					});
 


### PR DESCRIPTION
For Polycom Models, Prefix VVX in front of all VVX model names in Monster UI

The family information is already available on the payload, it just need to be added to the string displayed to avoid confusions.