### PR TITLE
add carrier api url

### DIFF
--- a/src/js/lib/jquery.kazoosdk.js
+++ b/src/js/lib/jquery.kazoosdk.js
@@ -553,6 +553,12 @@
 				'deleteNotification': { verb: 'DELETE', url: 'accounts/{accountId}/notifications/{notificationId}' },
 				'getDnsEntries': { verb: 'GET', url: 'accounts/{accountId}/whitelabel/domains' },
 				'checkDnsEntries': { verb: 'POST', url: 'accounts/{accountId}/whitelabel/domains?domain={domain}' }
+			},
+			localTrunks: {
+				'list': { 'verb': 'GET', 'url': 'accounts/{accountId}/local_resources' },
+				'get': { 'verb': 'GET', 'url': 'accounts/{accountId}/local_resources/{localResouceId}' },
+				'delete': { verb: 'DELETE', url: 'accounts/{accountId}/local_resources/{localResouceId}' },
+				'create': { verb: 'PUT', url: 'accounts/{accountId}/local_resources' }
 			}
 		},
 		authTokens = {};


### PR DESCRIPTION
I'm creating a new app to handle what was called "carrier" in the old ui (kazoo-ui api v1). I tested the API in the v2 sdk and they works as a charm but to use them with the kazoosdk I need them to be defined into the library. This tweak is just the api definitions.