### PR TITLE
Update conference binding format

### DIFF
--- a/src/apps/common/submodules/conferenceViewer/conferenceViewer.js
+++ b/src/apps/common/submodules/conferenceViewer/conferenceViewer.js
@@ -147,7 +147,7 @@ define(function(require) {
 			var self = this;
 
 			self.subscribeWebSocket({
-				binding: 'conference.event.' + conferenceId + '.*.*',
+				binding: 'conference.event.*.' + conferenceId + '.*',
 				requiredElement: template,
 				callback: function(event) {
 					self.conferenceViewerOnParticipantAction(event);


### PR DESCRIPTION


[conference binding changed for 5.x ](https://github.com/2600hz/kazoo-blackhole/commit/565b8a63d0b6e4bef05cffd0069be7cfa0c63533)

the format is now conference.event.`Event`.`ConferenceId`.`InstanceId`

this makes it easier to subscribe to conference.event.`conference-create`.\*.* when a `superduper` or `admin` wants to track conference creation or other relevant event
