### PR TITLE
MSTR-184: Unset auth token header on authentication requests

### DIFF
--- a/src/js/lib/jquery.kazoosdk.js
+++ b/src/js/lib/jquery.kazoosdk.js
@@ -646,7 +646,7 @@
 
 	function authFunction(settings, defaultSettings, url) {
 		var apiRoot = settings.apiRoot || defaultSettings.apiRoot;
-		request($.extend({}, defaultSettings, {
+		request(_.mergeWith({}, defaultSettings, {
 			url: apiRoot + url,
 			verb: 'PUT',
 			data: {
@@ -660,6 +660,10 @@
 				settings.success && settings.success(data, status, jqXHR);
 			},
 			error: settings.error
+		}, function(dest, src) {
+			return _.every([dest, src], _.isArray)
+				? _.chain(dest).concat(src).uniq().value()
+				: undefined;
 		}));
 	}
 

--- a/src/js/lib/jquery.kazoosdk.js
+++ b/src/js/lib/jquery.kazoosdk.js
@@ -652,6 +652,7 @@
 			data: {
 				data: settings.data
 			},
+			removeHeaders: ['X-Auth-Token'],
 			generateError: settings.hasOwnProperty('generateError') ? settings.generateError : true,
 			isRetryLoginRequest: settings.hasOwnProperty('isRetryLoginRequest') ? settings.isRetryLoginRequest : false,
 			success: function(data, status, jqXHR) {


### PR DESCRIPTION
Since 5.x, kazoo checks for and enforces `X-Auth-Token` header on authentication requests, making them fail when the token provided expired/is invalid.

This new behavior breaks down our current authentication mechanism, which by default, includes the current auth token on authentication requests.

To fix this, we set the `removeHeaders` prop on authentication requests to remove the `X-Auth-Token` header and make this behavior unoverridable as this behavior is tied to kazoo's implementation.