### PR TITLE
MSTR-195: Render currency symbol based on currency code

### DIFF
--- a/src/apps/myaccount/app.js
+++ b/src/apps/myaccount/app.js
@@ -234,10 +234,17 @@ define(function(require) {
 		},
 
 		render: function() {
-			var self = this;
+			var self = this,
+				resolveCurrencyCode = function resolveCurrencyCode() {
+					var fontAwesomeSupported = ['eur', 'gbp', 'ils', 'inr', 'jpy', 'krw', 'usd', 'rub', 'try'],
+						currencyCode = _.toLower(monster.config.currencyCode);
+
+					return _.find(fontAwesomeSupported, _.partial(_.isEqual, currencyCode));
+				};
 
 			self.formatUiRestrictions(monster.apps.auth.originalAccount.ui_restrictions, function(uiRestrictions) {
 				var dataTemplate = {
+						currencyCode: resolveCurrencyCode(),
 						restrictions: uiRestrictions
 					},
 					myaccountHtml = $(self.getTemplate({

--- a/src/apps/myaccount/views/app.html
+++ b/src/apps/myaccount/views/app.html
@@ -85,7 +85,7 @@
 				<li class="myaccount-element" data-module="transactions">
 					<a href="javascript:void(0);">
 						<div class="active-highlight">
-							<i class="fa fa-dollar"></i>
+							<i class="fa fa-{{coalesce currencyCode 'money'}}"></i>
 							<span class="element-name">{{ i18n.transactions.title }}</span>
 						</div>
 					</a>


### PR DESCRIPTION
The goal of this PR is to render Control Center's Transactions tab currency icon based on the currency code set in [monster ui's config](https://github.com/2600hz/monster-ui/blob/master/docs/configuration.md#settings).

Font Awesome supports 8 currency code symbols while the fallback icon used is [`fa-money`](https://fontawesome.com/v4.7.0/icon/money).

Example with `currencyCode: 'GBP'`:
![Capture](https://user-images.githubusercontent.com/1958193/93541416-41ac7880-f90b-11ea-8482-c1b64a1c7f15.PNG)

Example with `currencyCode: 'AUS'` (Australian Dollar, not supported by Font Awesome):
![Screenshot 2020-09-17 174743](https://user-images.githubusercontent.com/1958193/93542454-f2b41280-f90d-11ea-8c4a-167113a4e8d7.jpg)
