### PR TITLE
MSTR-197: Abstract appstore metadata management into methods

### DIFF
--- a/src/apps/appstore/app.js
+++ b/src/apps/appstore/app.js
@@ -1,12 +1,15 @@
 define(function(require) {
 	var $ = require('jquery'),
 		_ = require('lodash'),
-		monster = require('monster'),
-		isotope = require('isotope');
+		monster = require('monster');
+
+	require('isotope');
 
 	var app = {
 
 		name: 'appstore',
+
+		isMasqueradable: false,
 
 		css: [ 'app' ],
 
@@ -49,7 +52,7 @@ define(function(require) {
 				parent = container || $('#monster_content');
 
 			if (!monster.config.whitelabel.hasOwnProperty('hideAppStore') || monster.config.whitelabel.hideAppStore === false) {
-				self.loadData(function(appstoreData) {
+				self.loadData(function(err, appstoreData) {
 					self.renderApps(template, appstoreData);
 					self.bindEvents(template, appstoreData);
 				});
@@ -105,32 +108,25 @@ define(function(require) {
 		},
 
 		loadData: function(callback) {
-			var self = this;
+			var self = this,
+				isAppInstalled = function(app) {
+					return _.get(app, 'allowed_users', 'specific') !== 'specific'
+						|| !_.isEmpty(_.get(app, 'users', []));
+				};
 
 			monster.parallel({
-				apps: function(callback) {
-					self.callApi({
-						resource: 'appsStore.list',
-						data: {
-							accountId: self.accountId
-						},
-						success: function(data, status) {
-							callback(null, data.data);
-						}
-					});
+				apps: function(next) {
+					next(null, _.map(monster.util.listAppStoreMetadata(), function(app) {
+						return _.assign({}, app, {
+							tags: _
+								.chain(app)
+								.get('tags', [])
+								.concat(isAppInstalled(app) ? ['installed'] : [])
+								.value()
+						});
+					}));
 				},
-				account: function(callback) {
-					self.callApi({
-						resource: 'account.get',
-						data: {
-							accountId: self.accountId
-						},
-						success: function(data, status) {
-							callback(null, data.data);
-						}
-					});
-				},
-				users: function(callback) {
+				users: function(next) {
 					self.callApi({
 						resource: 'user.list',
 						data: {
@@ -140,36 +136,11 @@ define(function(require) {
 							}
 						},
 						success: function(data, status) {
-							callback(null, data.data);
+							next(null, data.data);
 						}
 					});
 				}
-			},
-			function(err, results) {
-				var parallelIconRequests = [];
-
-				results.apps.forEach(function(val) {
-					if ((val.hasOwnProperty('allowed_users') && val.allowed_users !== 'specific') || (val.hasOwnProperty('users') && val.users.length > 0)) {
-						val.tags ? val.tags.push('installed') : val.tags = [ 'installed' ];
-					}
-					var i18n = val.i18n[monster.config.whitelabel.language] || val.i18n['en-US'];
-
-					val.label = i18n.label;
-					val.description = i18n.description;
-					monster.ui.formatIconApp(val);
-					parallelIconRequests.push(function(parallelCallback) {
-						parallelCallback(null, monster.util.getAppIconPath(val));
-					});
-					delete val.i18n;
-				});
-
-				monster.parallel(parallelIconRequests, function(iconsErr, iconsResults) {
-					_.each(results.apps, function(app, index) {
-						app.icon = iconsResults[index];
-					});
-					callback(results);
-				});
-			});
+			}, callback);
 		},
 
 		renderApps: function(parent, appstoreData) {
@@ -201,83 +172,73 @@ define(function(require) {
 
 		showAppPopup: function(appId, appstoreData) {
 			var self = this,
-				userList = $.extend(true, [], appstoreData.users);
-
-			self.callApi({
-				resource: 'appsStore.get',
-				data: {
-					accountId: self.accountId,
-					appId: appId
-				},
-				success: function(data, status) {
-					var appData = monster.ui.formatIconApp(data.data),
-						dataI18n = appData.i18n[monster.config.whitelabel.language] || appData.i18n['en-US'],
-						app = $.extend(true, appData, {
-							extra: {
-								label: dataI18n.label,
-								description: dataI18n.description,
-								extendedDescription: dataI18n.extended_description,
-								features: dataI18n.features,
-								icon: _.find(appstoreData.apps, function(app) { return app.id === appData.id; }).icon,
-								screenshots: _.map(appData.screenshots || [], function(val, key) {
-									return self.apiUrl + 'apps_store/' + appData.id + '/screenshot/' + key + '?auth_token=' + self.getAuthToken();
-								})
-							}
-						}),
-						selectedUsersLength = app.users ? app.users.length : 0,
-						selectedUsersList = _.map(app.users || [], function(val) {
-							return val.id;
-						}),
-						users = _.map(userList, function(val, key) {
-							if (selectedUsersList.indexOf(val.id) >= 0) {
-								val.selected = true;
-							}
-							return val;
-						}),
-						template = $(self.getTemplate({
-							name: 'appPopup',
-							data: {
-								isWhitelabeling: monster.util.isWhitelabeling(),
-								app: app,
-								users: users,
-								i18n: {
-									selectedUsers: selectedUsersLength,
-									totalUsers: users.length
-								}
-							}
-						})),
-						rightContainer = template.find('.right-container'),
-						isActive = true;
-
-					if (!app.hasOwnProperty('allowed_users') || (app.allowed_users === 'specific' && (app.users || []).length === 0)) {
-						rightContainer.find('#app_switch').prop('checked', false);
-						rightContainer.find('.permissions-bloc').hide();
-						isActive = false;
-					} else if (app.allowed_users === 'admins') {
-						rightContainer.find('#app_popup_admin_only_radiobtn').prop('checked', true);
-					} else if (app.users && app.users.length > 0) {
-						rightContainer.find('#app_popup_specific_users_radiobtn').prop('checked', true);
-						rightContainer.find('.permissions-link').show();
-						rightContainer
-							.find('#app_popup_select_users_link')
-								.html(self.getTemplate({
-									name: '!' + self.i18n.active().selectUsersLink,
-									data: {
-										selectedUsers: selectedUsersLength
-									}
-								}));
+				metadata = monster.util.getAppStoreMetadata(appId),
+				userList = $.extend(true, [], appstoreData.users),
+				app = _.merge({
+					extra: _.merge({
+						extendedDescription: metadata.extended_description,
+						screenshots: _.map(metadata.screenshots || [], function(val, key) {
+							return self.apiUrl + 'apps_store/' + appId + '/screenshot/' + key + '?auth_token=' + self.getAuthToken();
+						})
+					}, _.pick(metadata, [
+						'label',
+						'description',
+						'features',
+						'icon'
+					]))
+				}, metadata),
+				selectedUsersLength = app.users ? app.users.length : 0,
+				selectedUsersList = _.map(app.users || [], function(val) {
+					return val.id;
+				}),
+				users = _.map(userList, function(val, key) {
+					if (selectedUsersList.indexOf(val.id) >= 0) {
+						val.selected = true;
 					}
+					return val;
+				}),
+				template = $(self.getTemplate({
+					name: 'appPopup',
+					data: {
+						isWhitelabeling: monster.util.isWhitelabeling(),
+						app: app,
+						users: users,
+						i18n: {
+							selectedUsers: selectedUsersLength,
+							totalUsers: users.length
+						}
+					}
+				})),
+				rightContainer = template.find('.right-container'),
+				isActive = true;
 
-					self.bindPopupEvents(template, app, isActive);
+			if (!app.hasOwnProperty('allowed_users') || (app.allowed_users === 'specific' && (app.users || []).length === 0)) {
+				rightContainer.find('#app_switch').prop('checked', false);
+				rightContainer.find('.permissions-bloc').hide();
+				isActive = false;
+			} else if (app.allowed_users === 'admins') {
+				rightContainer.find('#app_popup_admin_only_radiobtn').prop('checked', true);
+			} else if (app.users && app.users.length > 0) {
+				rightContainer.find('#app_popup_specific_users_radiobtn').prop('checked', true);
+				rightContainer.find('.permissions-link').show();
+				rightContainer
+					.find('#app_popup_select_users_link')
+						.html(self.getTemplate({
+							name: '!' + self.i18n.active().selectUsersLink,
+							data: {
+								selectedUsers: selectedUsersLength
+							}
+						}));
+			}
 
-					rightContainer.find('.selected-users-number').html(selectedUsersLength);
-					rightContainer.find('.total-users-number').html(users.length);
+			self.bindPopupEvents(template, app, isActive);
 
-					monster.ui.dialog(template, {title: app.extra.label});
+			rightContainer.find('.selected-users-number').html(selectedUsersLength);
+			rightContainer.find('.total-users-number').html(users.length);
 
-					template.find('#screenshot_carousel').carousel();
-				}
-			});
+			monster.ui.dialog(template, { title: app.extra.label });
+
+			template.find('#screenshot_carousel').carousel();
 		},
 
 		bindPopupEvents: function(parent, app, isActive) {
@@ -294,21 +255,6 @@ define(function(require) {
 							data: appInstallInfo
 						},
 						success: function(data, status) {
-							var allApps = monster.appsStore,
-								allowedUsers = _.get(data.data, 'allowed_users', null),
-								updatedApp = _.get(allApps, app.name, {}),
-								appUsers = _.get(data.data, 'users', []);
-
-							if (_.isEmpty(data.data)) {
-								allApps[app.name] = _.omit(updatedApp, ['users', 'allowed_users']);
-							} else {
-								_.assign(updatedApp, {
-									allowed_users: allowedUsers,
-									users: appUsers
-								});
-							}
-
-							monster.pub('apploader.destroy');
 							successCallback && successCallback();
 						},
 						error: function(_data, status) {
@@ -439,63 +385,26 @@ define(function(require) {
 			});
 
 			parent.find('#appstore_popup_save').on('click', function() {
-				if (parent.find('#app_switch').is(':checked')) {
-					var allowedUsers = parent.find('.permissions-bloc input[name="permissions"]:checked').val(),
-						selectedUsers = monster.ui.getFormData('app_popup_user_list_form').users || [];
+				var $button = $(this),
+					isEnabled = parent.find('#app_switch').is(':checked'),
+					allowedUsers = parent.find('.permissions-bloc input[name="permissions"]:checked').val(),
+					selectedUsers = monster.ui.getFormData('app_popup_user_list_form').users || [],
+					areNoSelectedUsers = allowedUsers === 'specific' && _.isEmpty(selectedUsers);
 
-					if (allowedUsers === 'specific' && selectedUsers.length === 0) {
-						monster.ui.alert(self.i18n.active().alerts.noUserSelected);
-					} else {
-						updateAppInstallInfo({
-							allowed_users: allowedUsers,
-							users: allowedUsers === 'specific' ? $.map(selectedUsers, function(val) {
-								return { id: val };
-							}) : []
-						},
-						function() {
-							var lang = monster.config.whitelabel.language,
-								isoFormattedLang = lang.substr(0, 3).concat(lang.substr(lang.length - 2, 2).toUpperCase()),
-								currentLang = app.i18n.hasOwnProperty(isoFormattedLang) ? isoFormattedLang : 'en-US',
-								appData = {
-									api_url: app.api_url,
-									icon: monster.util.getAppIconPath(app),
-									id: app.id,
-									label: app.i18n[currentLang].label,
-									name: app.name
-								};
-
-							// Add source_url only if it defined
-							if (app.hasOwnProperty('source_url')) {
-								appData.source_url = app.source_url;
-							}
-
-							// Only update variable if we're not masquerading and app isn't in installed apps yet.
-							if (!monster.util.isMasquerading() && !_.find(monster.apps.auth.installedApps, function(val) { return val.id === app.id; })) {
-								// Update local installedApps list by adding the new app
-								monster.apps.auth.installedApps.push(appData);
-							}
-
-							$('#appstore_container .app-element[data-id="' + app.id + '"]').addClass('installed');
-							$('#appstore_container .app-filter.active').click();
-
-							parent.closest(':ui-dialog').dialog('close');
-						});
-					}
-				} else {
-					updateAppInstallInfo({},
-					function() {
-						// Only update variable if we're not masquerading. Otherwise it would uninstall apps for the main account as well!
-						if (!monster.util.isMasquerading()) {
-							// Remove app from local installedApp list
-							monster.apps.auth.installedApps = monster.apps.auth.installedApps.filter(function(val) { return val.id !== app.id; });
-						}
-
-						$('#appstore_container .app-element[data-id="' + app.id + '"]').removeClass('installed');
-						$('#appstore_container .app-filter.active').click();
-
-						parent.closest(':ui-dialog').dialog('close');
-					});
+				if (isEnabled && areNoSelectedUsers) {
+					return monster.ui.alert(self.i18n.active().alerts.noUserSelected);
 				}
+
+				$button.prop('disabled', 'disabled');
+
+				updateAppInstallInfo(isEnabled ? {
+					allowed_users: allowedUsers,
+					users: allowedUsers === 'specific' ? _.map(selectedUsers, _.partial(_.set, {}, 'id')) : []
+				} : {}, function() {
+					parent.closest(':ui-dialog').dialog('close');
+					$('#appstore_container .app-element[data-id="' + app.id + '"]').toggleClass('installed', isEnabled);
+					$('#appstore_container .app-filter.active').click();
+				});
 			});
 		}
 

--- a/src/apps/auth/app.js
+++ b/src/apps/auth/app.js
@@ -51,6 +51,10 @@ define(function(require) {
 		},
 
 		subscribe: {
+			'auth.currentAppsStore.fetched': 'handleCurrentAppsStoreList',
+			'auth.currentAppsStore.updated': 'handleCurrentAppsStoreUpdate',
+			'auth.currentAppsStore.deleted': 'handleCurrentAppsStoreDelete',
+			'auth.currentUser.updated': 'handleCurrentUserUpdate',
 			'auth.logout': '_logout',
 			'auth.clickLogout': '_clickLogout',
 			'auth.initApp': '_initApp',
@@ -285,16 +289,6 @@ define(function(require) {
 				userId: data.data.owner_id
 			};
 
-			if ('apps' in data.data) {
-				self.installedApps = data.data.apps;
-			} else {
-				self.installedApps = [];
-				monster.ui.toast({
-					type: 'error',
-					message: self.i18n.active().toastrMessages.appListError
-				});
-			}
-
 			// We store the language so we can load the right language before having to query anything in our back-end. (no need to query account, user etc)
 			var cookieAuth = {
 				language: data.data.language,
@@ -340,11 +334,6 @@ define(function(require) {
 			var self = this;
 
 			monster.parallel({
-				appsStore: function(callback) {
-					self.getAppsStore(function(data) {
-						callback(null, data);
-					});
-				},
 				account: function(callback) {
 					self.getAccount(self.accountId, function(data) {
 						// The Kazoo Version is returned by all APIs. Since it won't change, we'll store it in this flag to display it in other places without querying APIs.
@@ -366,8 +355,6 @@ define(function(require) {
 				}
 			},
 			function(err, results) {
-				var defaultApp;
-
 				if (err) {
 					monster.util.logoutAndReload();
 				} else {
@@ -382,49 +369,61 @@ define(function(require) {
 					results.user.apps = results.user.apps || {};
 					results.account.apps = results.account.apps || {};
 
-					var afterLanguageLoaded = function() {
-						var fullAppList = _.keyBy(self.installedApps, 'id'),
-							defaultAppId = _.find(results.user.appList || [], function(appId) {
-								return fullAppList.hasOwnProperty(appId);
-							});
+					self.currentUser = results.user;
+					// This account will remain unchanged, it should be used by non-masqueradable apps
+					self.originalAccount = results.account;
+					// This account will be overriden when masquerading, it should be used by masqueradable apps
+					self.currentAccount = $.extend(true, {}, self.originalAccount);
 
-						if (defaultAppId) {
-							defaultApp = fullAppList[defaultAppId].name;
-						} else if (self.installedApps.length > 0) {
-							defaultApp = self.installedApps[0].name;
-						}
-
-						monster.appsStore = _.keyBy(results.appsStore, 'name');
-
-						_.each(monster.appsStore, function(app) {
-							if (
-								!_.has(app, 'extends')
-								|| !_.isArray(app.extends)
-							) {
-								return;
+					// If the user or the account we're logged into has a language settings, and if it's different than
+					var loadCustomLanguage = function(language, callback) {
+						monster.series([
+							function(next) {
+								if (_.includes([monster.config.whitelabel.language, monster.defaultLanguage], language)) {
+									return next(null);
+								}
+								monster.series(_.map([monster.apps.core, self], function(app) {
+									return function(next) {
+										monster.apps.loadLocale(app, language, _.partial(next, null));
+									};
+								}), next);
 							}
-							_.each(app.extends, function(extended) {
-								if (
-									!_.isString(extended)
-									|| !_.has(monster.appsStore, extended)
-								) {
-									return;
-								}
-								if (_.chain(monster.appsStore).get([extended, 'extensions'], []).includes(app.name).value()) {
-									return;
-								}
-								if (!_.has(monster.appsStore, [extended, 'extensions'])) {
-									_.set(monster.appsStore, [extended, 'extensions'], []);
-								}
-								monster.appsStore[extended].extensions.push(app.name);
-							});
+						], function() {
+							monster.config.whitelabel.language = language;
+							callback && callback();
 						});
+					};
 
-						self.currentUser = results.user;
-						// This account will remain unchanged, it should be used by non-masqueradable apps
-						self.originalAccount = results.account;
-						// This account will be overriden when masquerading, it should be used by masqueradable apps
-						self.currentAccount = $.extend(true, {}, self.originalAccount);
+					monster.parallel([
+						function(next) {
+							self.callApi({
+								resource: 'appsStore.list',
+								data: {
+									accountId: self.accountId
+								},
+								success: _.partial(next, null),
+								error: _.partial(next, 'appsStore')
+							});
+						},
+						function(next) {
+							/* If user has a preferred language, then set the i18n flag with this value, and download the customized i18n
+							if not, check if the account has a default preferred language */
+							var language = _
+								.chain([results.user, results.account])
+								.map('language')
+								.find(_.isString)
+								.value();
+
+							if (_.isUndefined(language)) {
+								return next(null);
+							}
+							loadCustomLanguage(language, _.partial(next, null));
+						}
+					], function(err) {
+						if (err === 'appsStore') {
+							return monster.util.logoutAndReload();
+						}
+						var defaultApp = self.getCurrentUserDefaultAppName();
 
 						self.defaultApp = defaultApp;
 
@@ -438,40 +437,14 @@ define(function(require) {
 							$('#main_topbar_account_toggle_link').addClass('visible');
 						}
 
-						monster.pub('core.initializeShortcuts', dataLogin.apps);
+						monster.pub('core.initializeShortcuts', monster.util.listAppStoreMetadata('user'));
 						monster.pub('core.socket.start');
 						monster.pub('webphone.start');
 
 						monster.pub('core.loadApps', {
 							defaultApp: defaultApp
 						});
-					};
-
-					// If the user or the account we're logged into has a language settings, and if it's different than
-					var loadCustomLanguage = function(language, callback) {
-						if (language !== monster.config.whitelabel.language && language !== monster.defaultLanguage) {
-							monster.apps.loadLocale(monster.apps.core, language, function() {
-								monster.apps.loadLocale(self, language, function() {
-									monster.config.whitelabel.language = language;
-
-									callback && callback();
-								});
-							});
-						} else {
-							monster.config.whitelabel.language = language;
-							callback && callback();
-						}
-					};
-
-					/* If user has a preferred language, then set the i18n flag with this value, and download the customized i18n
-					if not, check if the account has a default preferred language */
-					if ('language' in results.user) {
-						loadCustomLanguage(results.user.language, afterLanguageLoaded);
-					} else if ('language' in results.account) {
-						loadCustomLanguage(results.account.language, afterLanguageLoaded);
-					} else {
-						afterLanguageLoaded && afterLanguageLoaded();
-					}
+					});
 				}
 			});
 		},
@@ -1516,20 +1489,6 @@ define(function(require) {
 			});
 		},
 
-		getAppsStore: function(callback) {
-			var self = this;
-
-			self.callApi({
-				resource: 'appsStore.list',
-				data: {
-					accountId: self.accountId
-				},
-				success: function(_data) {
-					callback && callback(_data.data);
-				}
-			});
-		},
-
 		getUser: function(success, error) {
 			var self = this;
 
@@ -1555,26 +1514,27 @@ define(function(require) {
 		// Method used to authenticate other apps
 		_initApp: function(args) {
 			var self = this,
-				success = function(app) {
-					// If isMasqueradable flag is set in the code itself, use it, otherwise check if it's set in the DB, otherwise defaults to true
-					app.isMasqueradable = app.hasOwnProperty('isMasqueradable') ? app.isMasqueradable : (monster.appsStore.hasOwnProperty(app.name) ? monster.appsStore[app.name].masqueradable : true);
-					app.accountId = app.isMasqueradable && self.currentAccount ? self.currentAccount.id : self.accountId;
-					app.userId = self.userId;
+				app = args.app,
+				metadata = monster.util.getAppStoreMetadata(app.name),
+				callback = args.callback || function() {};
 
-					args.callback && args.callback();
-				},
-				installedApp = _.find(self.installedApps, function(val) {
-					return val.name === args.app.name;
-				});
-
-			if (installedApp && installedApp.api_url) {
-				args.app.apiUrl = installedApp.api_url;
-				if (args.app.apiUrl.substr(args.app.apiUrl.length - 1) !== '/') {
-					args.app.apiUrl += '/';
+			if (metadata && metadata.api_url) {
+				app.apiUrl = metadata.api_url;
+				if (app.apiUrl.substr(app.apiUrl.length - 1) !== '/') {
+					app.apiUrl += '/';
 				}
 			}
 
-			success(args.app);
+			// If isMasqueradable flag is set in the code itself, use it, otherwise check if it's set in the DB, otherwise defaults to true
+			app.isMasqueradable = _.find([
+				_.get(app, 'isMasqueradable'),
+				_.get(metadata, 'masqueradable'),
+				true
+			], _.isBoolean);
+			app.accountId = app.isMasqueradable && self.currentAccount ? self.currentAccount.id : self.accountId;
+			app.userId = self.userId;
+
+			callback();
 		},
 
 		triggerImpersonateUser: function(args) {
@@ -1611,6 +1571,156 @@ define(function(require) {
 					callback && callback(data);
 				}
 			});
+		},
+
+		maybeUpdateCurrentUserAppList: function(callback) {
+			if (!_.has(monster.apps, 'auth.currentUser')) {
+				return callback(null);
+			}
+			var self = this,
+				appIdsList = _.map(monster.util.listAppStoreMetadata('user'), 'id'),
+				linkIdsList = _.map(monster.util.listAppLinks(), 'id'),
+				actionIdsList = _.flatten([
+					linkIdsList,
+					appIdsList
+				]),
+				currentActionIdsList = _.get(monster.apps, 'auth.currentUser.appList', []),
+				defaultActionId = _
+					.chain(currentActionIdsList)
+					.find(_.partial(_.includes, appIdsList))
+					.defaultTo(_.head(appIdsList))
+					.value(),
+				newActionIdsList = _.difference(actionIdsList, currentActionIdsList),
+				validCurrentActionIdsList = _
+					.chain(currentActionIdsList)
+					.filter(_.partial(_.includes, actionIdsList))
+					.difference(newActionIdsList)
+					.value(),
+				normalizedUserActionIdsList = _
+					.chain([
+						[defaultActionId],
+						newActionIdsList,
+						validCurrentActionIdsList
+					])
+					.flatten()
+					.reject(_.isUndefined)
+					.uniq()
+					.value();
+
+			if (_.isEqual(currentActionIdsList, normalizedUserActionIdsList)) {
+				return callback(null);
+			}
+			self.callApi({
+				resource: 'user.patch',
+				data: {
+					accountId: self.accountId,
+					userId: self.userId,
+					data: {
+						appList: normalizedUserActionIdsList
+					}
+				},
+				success: _.partial(callback, null),
+				error: _.partial(callback, null)
+			});
+		},
+
+		handleCurrentAppsStoreList: function(args) {
+			var self = this,
+				appsStore = _.get(args, 'response', {}),
+				callback = _.get(args, 'callback', function() {}),
+				resolveExtensions = function(apps) {
+					_.forEach(apps, function(app) {
+						if (
+							!_.has(app, 'extends')
+							|| !_.isArray(app.extends)
+						) {
+							return;
+						}
+						_.each(app.extends, function(extended) {
+							if (
+								!_.isString(extended)
+								|| !_.has(apps, extended)
+							) {
+								return;
+							}
+							if (_.chain(apps).get([extended, 'extensions'], []).includes(app.name).value()) {
+								return;
+							}
+							if (!_.has(apps, [extended, 'extensions'])) {
+								_.set(apps, [extended, 'extensions'], []);
+							}
+							apps[extended].extensions.push(app.name);
+						});
+					});
+					return apps;
+				};
+
+			self.appsStore = resolveExtensions(appsStore);
+
+			self.maybeUpdateCurrentUserAppList(callback);
+		},
+
+		handleCurrentAppsStoreUpdate: function(args) {
+			var self = this,
+				data = _.get(args, 'request', {}),
+				callback = _.get(args, 'callback', function() {}),
+				app = _
+					.chain(self)
+					.get('appsStore', [])
+					.find({ id: data.appId })
+					.value();
+
+			_.assign(app, _.pick(data.data, [
+				'allowed_users',
+				'users'
+			]));
+
+			self.maybeUpdateCurrentUserAppList(callback);
+		},
+
+		handleCurrentAppsStoreDelete: function(args) {
+			var self = this,
+				data = _.get(args, 'request', {}),
+				callback = _.get(args, 'callback', function() {}),
+				app = _
+					.chain(self)
+					.get('appsStore', [])
+					.find({ id: data.appId })
+					.value();
+
+			_.forEach(['allowed_users', 'users'], _.partial(_.unset, app));
+
+			self.maybeUpdateCurrentUserAppList(callback);
+		},
+
+		handleCurrentUserUpdate: function(args) {
+			var self = this,
+				updatedUser = _.get(args, 'response', {}),
+				callback = _.get(args, 'callback', function() {}),
+				cookieData = monster.cookies.getJson('monster-auth');
+
+			self.currentUser = updatedUser;
+			self.defaultApp = self.getCurrentUserDefaultAppName();
+
+			// If auth cookie language is different than the user updated one, we update it.
+			if (cookieData.language !== updatedUser.language) {
+				monster.cookies.set('monster-auth', _.merge({}, cookieData, _.pick(updatedUser, [
+					'language'
+				])));
+			}
+
+			callback(null);
+		},
+
+		/**
+		 * Returns default app name for current user.
+		 * @return {String|Undefined} Default app name for current user.
+		 */
+		getCurrentUserDefaultAppName: function() {
+			return _.flow(
+				monster.util.getCurrentUserDefaultApp,
+				_.partial(_.get, _, 'name')
+			)();
 		}
 	};
 

--- a/src/apps/common/submodules/appSelector/appSelector.js
+++ b/src/apps/common/submodules/appSelector/appSelector.js
@@ -75,7 +75,6 @@ define(function(require) {
 		 * @param  {String} [args.accountId=self.accountId]  ID of the account from which to get
 		 *                                                   the app list
 		 * @param  {('all'|'account'|'user')} [args.scope='all']  App list scope
-		 * @param  {Boolean} [args.forceFetch=false]  Force to fetch app data from API instead of
 		 *                                            using the cached one
 		 * @param  {String[]} [args.availableApps=[]]  List of IDs for the specific apps to be
 		 *                                             displayed. This is applied on top of the
@@ -91,7 +90,6 @@ define(function(require) {
 			var self = this,
 				accountId = _.get(args, 'accountId', self.accountId),
 				scope = _.get(args, 'scope', 'all'),
-				forceFetch = _.get(args, 'forceFetch', false),
 				availableApps = _.get(args, 'availableApps'),
 				excludedApps = _.get(args, 'excludedApps'),
 				selectedAppIds = _.get(args, 'selectedAppIds', []),
@@ -157,7 +155,6 @@ define(function(require) {
 			monster.pub('apploader.getAppList', {
 				accountId: accountId,
 				scope: scope,
-				forceFetch: forceFetch || accountId !== self.accountId,
 				success: function(appList) {
 					var $template;
 
@@ -209,7 +206,6 @@ define(function(require) {
 		 * @param  {String} [args.accountId=self.accountId]  ID of the account from which to get
 		 *                                                   the app list
 		 * @param  {('all'|'account'|'user')} [args.scope='all'] App list scope
-		 * @param  {Boolean} [args.forceFetch=false]  Force to fetch app data from API instead of
 		 *                                            using the cached one
 		 * @param  {String[]} [args.availableApps=[]]  List of IDs for the specific apps to be
 		 *                                              displayed. This is applied on top of the
@@ -235,7 +231,6 @@ define(function(require) {
 					.pick([
 						'accountId',
 						'scope',
-						'forceFetch',
 						'availableApps',
 						'excludedApps',
 						'selectedAppIds'

--- a/src/apps/common/submodules/servicePlanDetails/servicePlanDetails.js
+++ b/src/apps/common/submodules/servicePlanDetails/servicePlanDetails.js
@@ -349,10 +349,12 @@ define(function(require) {
 					formattedData.overrides[plan][category][key] = formattedData.overrides[plan][category][key] || {};
 
 					if (category === 'ui_apps') {
+						var app = monster.util.getAppStoreMetadata(key);
+
 						formattedData.overrides[plan][category][key] = {
 							enabled: true,
-							app_id: monster.appsStore[key].id,
-							name: monster.appsStore[key].i18n['en-US'].label,
+							app_id: app.id,
+							name: app.label,
 							account_id: monster.apps.auth.originalAccount.id
 						};
 					}

--- a/src/apps/common/submodules/servicePlanItemEditor/servicePlanItemEditor.js
+++ b/src/apps/common/submodules/servicePlanItemEditor/servicePlanItemEditor.js
@@ -154,9 +154,10 @@ define(function() {
 					.map(function(item) {
 						return {
 							value: item,
-							label: _.includes(['account_apps', 'user_apps'], category) && _.has(monster.appsStore, item)
-								? monster.appsStore[item].i18n[monster.config.whitelabel.language].label
-								: monster.util.tryI18n(self.i18n.active().servicePlanItemEditor.keys, item)
+							label: _.find([
+								_.includes(['account_apps', 'user_apps'], category) && _.get(monster.util.getAppStoreMetadata(item), 'label'),
+								monster.util.tryI18n(self.i18n.active().servicePlanItemEditor.keys, item)
+							], _.isString)
 						};
 					})
 					.sortBy('label')
@@ -486,13 +487,14 @@ define(function() {
 			});
 
 			if (category === 'ui_apps') {
-				if (monster.appsStore.hasOwnProperty(key)) {
-					var accId = monster.appsStore[key].account_id;
+				var app = monster.util.getAppStoreMetadata(key);
+				if (app) {
+					var accId = app.account_id;
 					var formattedAccDb = 'account%2F' + accId.substring(0, 2) + '%2F' + accId.substr(2, 2) + '%2F' + accId.substr(4, accId.length - 4);
-					formattedItem.app_id = monster.appsStore[key].id;
+					formattedItem.app_id = app.id;
 					formattedItem.account_db = formattedAccDb;
 				}
-				if (monster.appsStore.hasOwnProperty(key) || key === '_all') {
+				if (app || key === '_all') {
 					// UI-3137: automatically enable apps when added
 					formattedItem.enabled = true;
 				}

--- a/src/apps/core/app.js
+++ b/src/apps/core/app.js
@@ -170,37 +170,29 @@ define(function(require) {
 		 */
 		showAppName: function(pName) {
 			var self = this,
+				apps = monster.util.listAppStoreMetadata('user'),
 				name = _.isString(pName) ? pName : monster.apps.getActiveApp(),
 				$navbar = $('.core-topbar'),
 				$current = $navbar.find('#main_topbar_current_app'),
+				app = _
+					.chain([{
+						name: 'myaccount',
+						label: self.i18n.active().controlCenter,
+						icon: monster.util.getAppIconPath({ name: 'myaccount' })
+					}])
+					.concat(apps)
+					.find({ name: name })
+					.value(),
 				$new = name !== 'appstore' ? $(self.getTemplate({
 					name: 'current-app',
-					data: _
-						.chain(monster.apps.auth.installedApps)
-						.concat([{
-							name: 'myaccount',
-							label: self.i18n.active().controlCenter
-						}])
-						.filter({ name: name })
-						.map(function(app) {
-							return _
-								.chain({
-									icon: monster.util.getAppIconPath(app)
-								})
-								.merge(app)
-								.thru(monster.ui.formatIconApp)
-								.value();
-						})
-						.find({ name: name })
-						.value()
+					data: app
 				})) : '';
 
-			$current.fadeOut(100, function() {
-				$current
-					.empty()
-					.append($new)
-					.fadeIn(100);
-			});
+			$current
+				.hide()
+				.empty()
+				.append($new)
+				.fadeIn(200);
 		},
 
 		isActiveAppPlugin: function isActiveAppPlugin(callback) {

--- a/src/js/lib/monster.routing.js
+++ b/src/js/lib/monster.routing.js
@@ -43,7 +43,7 @@ define(function(require) {
 			if (
 				appName !== 'appstore'
 				&& monster.util.isMasquerading()
-				&& monster.appsStore[appName].masqueradable !== true
+				&& !monster.util.getAppStoreMetadata(appName).masqueradable
 			) {
 				monster.ui.toast({
 					type: 'error',
@@ -108,22 +108,14 @@ define(function(require) {
 				if (!monster.util.isLoggedIn()) {
 					return;
 				}
-				monster.pub('apploader.getAppList', {
-					scope: 'user',
-					accountId: _.get(monster.apps.auth, [
-						monster.util.isMasquerading() ? 'originalAccount' : 'currentAccount',
-						'id'
-					]),
-					success: function(availableApps) {
-						// try loading the requested app
-						if (isAppLoadable(appName, availableApps)) {
-							loadApp(appName, query, availableApps);
-						} else {
-							handleInvalidAppLoad(availableApps);
-						}
-					},
-					error: monster.util.logoutAndReload.bind(monster.util)
-				});
+				var availableApps = monster.util.listAppStoreMetadata('user');
+
+				// try loading the requested app
+				if (isAppLoadable(appName, availableApps)) {
+					loadApp(appName, query, availableApps);
+				} else {
+					handleInvalidAppLoad(availableApps);
+				}
 			});
 		},
 

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -2893,20 +2893,6 @@ define(function(require) {
 			self.handleDisplayFootable(container, finalOptions);
 		},
 
-		formatIconApp: function(app) {
-			if (app && app.hasOwnProperty('name')) {
-				if (monster.appsStore.hasOwnProperty(app.name)) {
-					if (monster.appsStore[app.name].phase === 'beta') {
-						app.extraCssClass = 'beta-overlay-icon';
-					} else if (monster.appsStore[app.name].phase === 'alpha') {
-						app.extraCssClass = 'alpha-overlay-icon';
-					}
-				}
-			}
-
-			return app;
-		},
-
 		// Takes a file in parameter, and then outputs the PDF preview of that file in an iframe that's added to the container
 		renderPDF: function(file, container, pOptions) {
 			var self = this,

--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -6,7 +6,6 @@ define(function(require) {
 		moment = require('moment');
 
 	require('moment-timezone');
-	//momentTimezone = require('moment-timezone');
 
 	var util = {
 
@@ -651,26 +650,6 @@ define(function(require) {
 			return true;
 		},
 
-		// Monster helper used to get the path to the icon of an app
-		// Some app have their icons loaded locally, whereas some new apps won't have them
-		getAppIconPath: function(app) {
-			var self = this,
-				response,
-				authApp = monster.apps.auth,
-				localIcons = ['accounts', 'auth-security', 'blacklists', 'branding', 'callflows', 'callqueues', 'call-recording', 'carriers',
-					'cluster', 'conferences', 'csv-onboarding', 'debug', 'developer', 'dialplans', 'duo', 'fax', 'integration-aws', 'integration-google-drive',
-					'migration', 'mobile', 'myaccount', 'numbers', 'operator', 'operator-pro', 'pbxs', 'pivot', 'port', 'provisioner', 'reporting', 'reseller_reporting',
-					'service-plan-override', 'tasks', 'taxation', 'userportal', 'voicemails', 'voip', 'webhooks', 'websockets'];
-
-			if (localIcons.indexOf(app.name) >= 0) {
-				response = 'css/assets/appIcons/' + app.name + '.png';
-			} else {
-				response = authApp.apiUrl + 'accounts/' + authApp.accountId + '/apps_store/' + app.id + '/icon?auth_token=' + self.getAuthToken();
-			}
-
-			return response;
-		},
-
 		guid: function() {
 			var result = '';
 
@@ -679,17 +658,6 @@ define(function(require) {
 			}
 
 			return result;
-		},
-
-		getAuthToken: function(pConnectionName) {
-			var self = this,
-				authToken;
-
-			if (monster && monster.hasOwnProperty('apps') && monster.apps.hasOwnProperty('auth')) {
-				authToken = monster.apps.auth.getAuthTokenByConnection(pConnectionName);
-			}
-
-			return authToken;
 		},
 
 		getVersion: function() {
@@ -982,6 +950,87 @@ define(function(require) {
 			.value();
 	}
 	util.formatVariableToDisplay = formatVariableToDisplay;
+
+	/**
+	 * Returns an app's icon path/URL.
+	 * @param  {Object} app
+	 * @param  {String} app.name
+	 * @param  {String} app.id
+	 * @return {String}
+	 *
+	 * Some app have their icons loaded locally, whereas some new apps won't have them.
+	 */
+	function getAppIconPath(app) {
+		var authApp = monster.apps.auth;
+		var localIcons = [
+			'accounts',
+			'auth-security',
+			'blacklists',
+			'branding',
+			'callflows',
+			'callqueues',
+			'call-recording',
+			'carriers',
+			'cluster',
+			'conferences',
+			'csv-onboarding',
+			'debug',
+			'developer',
+			'dialplans',
+			'duo',
+			'fax',
+			'integration-aws',
+			'integration-google-drive',
+			'migration',
+			'mobile',
+			'myaccount',
+			'numbers',
+			'operator',
+			'operator-pro',
+			'pbxs',
+			'pivot',
+			'port',
+			'provisioner',
+			'reporting',
+			'reseller_reporting',
+			'service-plan-override',
+			'tasks',
+			'taxation',
+			'userportal',
+			'voicemails',
+			'voip',
+			'webhooks',
+			'websockets'
+		];
+
+		if (_.includes(localIcons, app.name)) {
+			return 'css/assets/appIcons/' + app.name + '.png';
+		} else {
+			return _.join([
+				authApp.apiUrl,
+				'accounts/',
+				authApp.accountId,
+				'/apps_store/',
+				app.id,
+				'/icon?auth_token=',
+				getAuthToken()
+			], '');
+		}
+	}
+	util.getAppIconPath = getAppIconPath;
+
+	/**
+	 * Returns the auth token of a given connection.
+	 * @param  {String} [pConnectionName]
+	 * @return {String|Undefined}
+	 */
+	function getAuthToken(pConnectionName) {
+		if (!isLoggedIn()) {
+			return;
+		}
+		return monster.apps.auth.getAuthTokenByConnection(pConnectionName);
+	}
+	util.getAuthToken = getAuthToken;
 
 	/**
 	 * Returns a list of bookkeepers available for Monster UI


### PR DESCRIPTION
The goal of this PR is to abstract away app store data management operations so that app metadata access is normalized. The purpose of this change is to allow for app metadata branding on top of internationalization resolution.

## New utils of note

### `monster.util#getAppStoreMetadata`
Returns metadata for an appstore app formatted by resolving its icon path and i18n entry. It is this formatting logic that will be augmented later to resolve i18n based on branding configuration.
App metadata is retrieved from the current appstore, which corresponds to the current account. To perform the same operation for a different list of apps, we can use `monster.util#getAppMetadata` by providing it a custom list.

### `monster.util#listAppStoreMetadata`
Returns formatted apps metadata filtered for a specific scope (`all|account|user`). Similarly to `monster.util#getAppStoreMetadata`, the apps metadata it retrieved from the current appstore. When the `user` scope is used, apps will be filtered against the current user.

To perform the same listing operation on a specific list of apps, `monster.util.listAppsMetadata` can be used. To perform the same listing operation for a specific user, we can use `monster.util#listAppsMetadata` and filter the results with `monster.util#isUserPermittedApp` by providing it a user to filter against.

### `monster.util#getCurrentUserDefaultApp`
Resolves the default app for current user by checking the `appList`'s document prop against the appstore. When no valid app is found, get the first one accessible (if any) for the user from the appstore.

## Update of existing behaviors

### `apploader#getAppList`
Was updated to use the new utils when fetching apps metadata for the current appstore. The `forceFetch` parameter was replaced by checking the presence of `accountId`. Only when `accountId` is different than the original account ID (for which the locally stored appstore corresponds to) does an API request is made to fetch the appstore.

It is also possible to provide a `user` parameter to filter the listing against. Note that when listing the appstore apps for the current appstore, when `user` is not provided but `scope='user'`, the listing will be filtered against the current user.

### `appstore#loadData`/`appstore#showAppPopup`
Use current appstore to list/get apps metadata instead of retrieving over the wire.

### `monster.appsStore`
Since the appstore list represents apps available for the account that originally logged in, this is now stored inside the `auth` module at it is based on the authentication session.

It also becomes a list as it shouldn't be accessed manually anymore (either for lookup or update). Updates are now restricted to the `auth` module, triggered by message bus events to keep local data in sync., while access is restricted to `monster.util#getAppStoreMetadata` and `monster.util#listAppStoreMetadata`.

## New behaviors

### `auth.currentAppsStore.fetched|updated|deleted`
Listens for requests listing/modifying the current appstore and update our local copy accordingly. We do this to keep our local copy as up-to-date as possible, avoiding a round trip when app metadata is needed.

Those events potentially trigger `auth.currentUser.updated` when current user's `appList` needs to be updated, to keep current user's `appList` up-to-date.

### `auth.currentUser.updated`
Similar to previous appstore events, but for current user updates. It refreshes our local copy of current user as well as cookies locale when necessary.

----
Related PRs:
- https://github.com/2600hz/monster-ui-accounts/pull/169
- https://github.com/2600hz/monster-ui-service-plan-override/pull/48
- https://github.com/2600hz/monster-ui-service-planner/pull/40