### PR TITLE
MACT-91: Use disabled prop for wizard done button

### DIFF
--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -612,11 +612,11 @@ define(function(require) {
 				};
 
 			if (!result.valid) {
-				//If it fails for any reason then re-enable the button
+				//If validation fails for any reason then re-enable the button
 				wizardArgs
 					.container
 						.find('#done')
-						.removeClass('disabled');
+						.prop('disabled', false);
 				return;
 			}
 

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -324,12 +324,13 @@ define(function(require) {
 
 			//Clicking on the menu item
 			$template
-				.on('click', '.visited, .completed', function() {
-					var stepId = $(this).data('id');
-					self.navigationWizardGoToStep({
-						stepId: stepId
+				.find('.nav')
+					.on('click', '.visited, .completed', function() {
+						var stepId = $(this).data('id');
+						self.navigationWizardGoToStep({
+							stepId: stepId
+						});
 					});
-				});
 		},
 
 		/**

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -307,20 +307,20 @@ define(function(require) {
 					});
 
 			$template
-					.find('#navigation_wizard_delete')
-						.on('click', function(event) {
-							event.preventDefault();
+				.find('#navigation_wizard_delete')
+					.on('click', function(event) {
+						event.preventDefault();
 
-							var deleteFunctionRef = wizardArgs.delete,
-								deleteFunction = _.isFunction(deleteFunctionRef)
-									? deleteFunctionRef
-									: thisArg[deleteFunctionRef],
-								deleteCallback = function(callbackArgs) {
-									return callbackArgs.exit && self.navigationWizardUnbindEvents();
-								};
+						var deleteFunctionRef = wizardArgs.delete,
+							deleteFunction = _.isFunction(deleteFunctionRef)
+								? deleteFunctionRef
+								: thisArg[deleteFunctionRef],
+							deleteCallback = function(callbackArgs) {
+								return callbackArgs.exit && self.navigationWizardUnbindEvents();
+							};
 
-							_.bind(deleteFunction, thisArg)(wizardArgs, deleteCallback);
-						});
+						_.bind(deleteFunction, thisArg)(wizardArgs, deleteCallback);
+					});
 
 			//Clicking on the menu item
 			$template

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -207,19 +207,23 @@ define(function(require) {
 					});
 
 			$template
-				.on('click', '#done:not(.disabled)', function(event) {
-					event.preventDefault();
+				.find('#done')
+					.on('click', function(event) {
+						var $this = $(this);
 
-					$this = $(this);
+						event.preventDefault();
 
-					//disable button after it's clicked
-					$this
-						.addClass('disabled');
+						if ($this.prop('disabled')) {
+							return;
+						}
 
-					self.navigationWizardComplete({
-						eventType: 'done'
+						// Disable button after it's clicked
+						$this.prop('disabled', true);
+
+						self.navigationWizardComplete({
+							eventType: 'done'
+						});
 					});
-				});
 
 			$template
 				.find('#save_app, #navigation_wizard_save')

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -209,16 +209,10 @@ define(function(require) {
 			$template
 				.find('#done')
 					.on('click', function(event) {
-						var $this = $(this);
-
 						event.preventDefault();
 
-						if ($this.prop('disabled')) {
-							return;
-						}
-
 						// Disable button after it's clicked
-						$this.prop('disabled', true);
+						$(this).prop('disabled', true);
 
 						self.navigationWizardComplete({
 							eventType: 'done'


### PR DESCRIPTION
Use the `disabled` property instead of a class to disable the navigation wizard's done button. This in turn allows the done button to be re-enabled when the step is rendered again, which solves the issue of it remaining disabled even after changing the account name.