### PR TITLE
[5.0] MACT-91: Use disabled prop for wizard done button

### DIFF
--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -272,12 +272,13 @@ define(function(require) {
 
 			//Clicking on the menu item
 			template
-				.on('click', '.visited, .completed', function() {
-					var stepId = $(this).data('id');
-					self.navigationWizardGoToStep({
-						stepId: stepId
+				.find('.nav')
+					.on('click', '.visited, .completed', function() {
+						var stepId = $(this).data('id');
+						self.navigationWizardGoToStep({
+							stepId: stepId
+						});
 					});
-				});
 		},
 
 		/**

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -550,11 +550,11 @@ define(function(require) {
 				});
 
 			if (!result.valid) {
-				//If it fails for any reason then re-enable the button
+				//If validation fails for any reason then re-enable the button
 				wizardArgs
 					.container
 						.find('#done')
-						.removeClass('disabled');
+						.prop('disabled', false);
 				return;
 			}
 

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -173,19 +173,23 @@ define(function(require) {
 					});
 
 			template
-				.on('click', '#done:not(.disabled)', function(event) {
-					event.preventDefault();
+				.find('#done')
+					.on('click', function(event) {
+						var $this = $(this);
 
-					$this = $(this);
+						event.preventDefault();
 
-					//disable button after it's clicked
-					$this
-						.addClass('disabled');
+						if ($this.prop('disabled')) {
+							return;
+						}
 
-					self.navigationWizardComplete({
-						eventType: 'done'
+						// Disable button after it's clicked
+						$this.prop('disabled', true);
+
+						self.navigationWizardComplete({
+							eventType: 'done'
+						});
 					});
-				});
 
 			template
 				.find('#save_app')

--- a/src/apps/common/submodules/navigationWizard/navigationWizard.js
+++ b/src/apps/common/submodules/navigationWizard/navigationWizard.js
@@ -175,16 +175,10 @@ define(function(require) {
 			template
 				.find('#done')
 					.on('click', function(event) {
-						var $this = $(this);
-
 						event.preventDefault();
 
-						if ($this.prop('disabled')) {
-							return;
-						}
-
 						// Disable button after it's clicked
-						$this.prop('disabled', true);
+						$(this).prop('disabled', true);
 
 						self.navigationWizardComplete({
 							eventType: 'done'


### PR DESCRIPTION
Use the `disabled` property instead of a class to disable the navigation wizard's done button. This in turn allows the done button to be re-enabled when the step is rendered again, which solves the issue of it remaining disabled even after changing the account name.

**NOTE:** This change differs a bit from [`MACT-91`](https://github.com/2600hz/monster-ui/pull/861) because the changes for the Port Request Wizard in MSTR-76 were [reverted](https://github.com/2600hz/monster-ui/commit/d892e0bbd1edb51b66675596cb3337c46cb768c3) in the `5.0` branch.