### PR TITLE
MSPB-167: Fix: SmartPBX does not set account emergency caller ID when main number is selected

### DIFF
--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -636,6 +636,29 @@
 		"__version": "4.1",
 		"numbersCarrierModule": {
 			"custom": "Custom"
+		},
+		"updateCallerIdDialog": {
+			"title": {
+				"emergency": "Account Emergency Caller-ID",
+				"external": "Account External Caller-ID"
+			},
+			"headerAddNumber": {
+				"emergency": "You've just turned E911 on one of your main number, please select which number you would like to use for your Account Emergency Caller-ID."
+			},
+			"headerRemoveNumber": {
+				"emergency": "You've disabled E911 on the number that was used for your Emergency Caller-ID, please select a new number to use as this Account Emergency Caller-ID."
+			},
+			"headerChooseNumber": {
+				"emergency": "You've not set the emergency number for the account yet, please select which number you would like to use for your Account Emergency Caller-ID.",
+				"external": "You've not set the external number for the account yet, please select a new number to use as this Account External Caller-ID."
+			},
+			"success": {
+				"emergency": "You successfully updated the E911 on the account to be {{ number }}.",
+				"external": "You successfully updated the external caller ID on the account to be {{ number }}."
+			},
+			"current": {
+				"emergency": "Current one"
+			}
 		}
 	},
 

--- a/src/apps/common/submodules/numbers/numbers.scss
+++ b/src/apps/common/submodules/numbers/numbers.scss
@@ -1,4 +1,5 @@
 @import "../../../../css/partials/base";
+@import "./partials/changeCallerIdPopup";
 
 #numbers_container {
 	display: block;

--- a/src/apps/common/submodules/numbers/partials/_changeCallerIdPopup.scss
+++ b/src/apps/common/submodules/numbers/partials/_changeCallerIdPopup.scss
@@ -1,0 +1,34 @@
+.e911-change-wrapper {
+	padding: 15px;
+	width: 400px;
+
+	.cancel-link {
+		margin-right: 5px;
+	}
+
+	.list-choices {
+		margin-bottom: 20px;
+		margin-top: 20px;
+
+		.choice {
+			background: #EEE;
+			padding: 20px;
+			border: 1px solid #CCC;
+			margin-bottom: 5px;
+
+			&:hover {
+				background: #FFF;
+				cursor: pointer;
+			}
+
+			&.active {
+				background: #FFF;
+				border: 1px solid #22a5ff;
+			}
+		}
+	}
+
+	.actions {
+		margin-top: 10px;
+	}
+}

--- a/src/apps/common/submodules/numbers/views/changeCallerIdPopup.html
+++ b/src/apps/common/submodules/numbers/views/changeCallerIdPopup.html
@@ -1,0 +1,30 @@
+<div class="e911-change-wrapper">
+	<div class="header">
+		{{#compare action "===" "choose"}}
+			{{ tryI18n i18n.numbers.updateCallerIdDialog.headerChooseNumber callerIdType }}
+		{{else}}
+			{{#compare action "===" "add"}}
+				{{ tryI18n i18n.numbers.updateCallerIdDialog.headerAddNumber callerIdType }}
+			{{else}}
+				{{ tryI18n i18n.numbers.updateCallerIdDialog.headerRemoveNumber callerIdType }}
+			{{/compare}}
+		{{/compare}}
+	</div>
+
+	<div class="list-choices">
+		{{#if oldNumber}}
+			<div class="choice active" data-number="{{oldNumber}}">{{ formatPhoneNumber oldNumber }} <span class="current">({{ tryI18n i18n.strategy.updateCallerIdDialog.current callerIdType }})</span></div>
+		{{/if}}
+
+		{{#each newNumbers}}
+			<div class="choice{{#unless ../oldNumber}}{{#if @first}} active{{/if}}{{/unless}}" data-number="{{this}}">{{ formatPhoneNumber this }}</div>
+		{{/each}}
+	</div>
+
+	<div class="actions clearfix">
+		<div class="pull-right">
+			<a class="cancel-link monster-link blue" href="javascript:void(0);">{{ i18n.cancel }}</a>
+			<button type="button" class="monster-button monster-button-success save">{{ i18n.save }}</button>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Hi @azefiel ,

What I found here is that the emergency number isn't assigned to the account when the 911 number is added from the numbers app.

Any comment suggestion are welcome!