### PR TITLE
MPRO-29: Extending monster ui mask for ipv4 and to accept other custom patterns

### DIFF
--- a/docs/monster-ui/mask().md
+++ b/docs/monster-ui/mask().md
@@ -4,14 +4,15 @@ title: mask()
 
 ## Syntax
 ```javascript
-monster.ui.mask(target, type);
+monster.ui.mask(target, type[, options]);
 ```
 
 ### Parameters
 Key | Description | Type | Default | Required
 :-: | --- | :-: | :-: | :-:
 `target` | Field on which the method will be applied. | `jQuery` | | `true`
-`type` | Type of mask to apply. | `String('phoneNumber' | 'macAddress')` | | `true`
+`type` | Type of mask to apply. Available presets: `'phoneNumber', 'macAddress' 'ipv4', 'extension'`. | `String('phoneNumber' | 'macAddress' | 'AAA 000-S0S'))` | | `true`
+`options` | Options to be applied in case `type` parameter is not a preset. ([check available options][mask-plugin])| `Object` | | `false`
 
 ## Description
 This helper is a wrapper over the [jQuery Mask plugin][mask-plugin].

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -2685,8 +2685,8 @@ define(function(require) {
 			self.onNavbarTabClick(thisArg, $tab, oArgs);
 		},
 
-		mask: function(target, type) {
-			var validations = {
+		mask: function(target, type, options) {
+			var config = _.get({
 				phoneNumber: {
 					mask: 'AZZZZZZZZZZZZZZZZ',
 					options: {
@@ -2712,6 +2712,17 @@ define(function(require) {
 						}
 					}
 				},
+				ipv4: {
+					mask: '0ZZ.0ZZ.0ZZ.0ZZ',
+					options: {
+						translation: {
+							'Z': {
+								pattern: /[0-9]/,
+								optional: true
+							}
+						}
+					}
+				},
 				extension: {
 					mask: 'ZZZZZZZZZZZZZZZZ',
 					options: {
@@ -2723,15 +2734,12 @@ define(function(require) {
 						}
 					}
 				}
-			};
+			}, type, {
+				mask: type,
+				options: options
+			});
 
-			if (validations.hasOwnProperty(type)) {
-				var data = validations[type];
-
-				target.mask(data.mask, data.options);
-			} else {
-				console.warn('monster.ui.mask: parameter type\'s value "' + type + '" not a valid option');
-			}
+			target.mask(config.mask, config.options);
 		},
 
 		keyboardShortcuts: {},


### PR DESCRIPTION
ipv4 pattern is now a part of the presets
Accepts other patterns if the specified type is not a preset, uses options the same as jquery mask