### PR TITLE
[4.3] SPRO-103: Make footable page sizes customizable

### DIFF
--- a/src/apps/core/i18n/de-DE.json
+++ b/src/apps/core/i18n/de-DE.json
@@ -750,11 +750,7 @@
 	"__version": "v4.0",
 	"tablePageSize": {
 		"show": "Anzeigen",
-		"entries": "Einträge",
-		"ten": "10",
-		"twentyFive": "25",
-		"fifty": "50",
-		"hundred": "100"
+		"entries": "Einträge"
 	},
 
 	"__comment": "UI-2596: Hinzufügen von ISO-Ländern zur Internationalisierung",

--- a/src/apps/core/i18n/en-US.json
+++ b/src/apps/core/i18n/en-US.json
@@ -780,11 +780,7 @@
 	"__version": "v4.0",
 	"tablePageSize": {
 		"show": "Show",
-		"entries": "entries",
-		"ten": "10",
-		"twentyFive": "25",
-		"fifty": "50",
-		"hundred": "100"
+		"entries": "entries"
 	},
 
 	"__comment": "UI-2596: Adding ISO Countries to i18n",

--- a/src/apps/core/views/monster-table-pageSize.html
+++ b/src/apps/core/views/monster-table-pageSize.html
@@ -2,10 +2,9 @@
 	<span class="label label-default">{{i18n.tablePageSize.show}}</span>
 	<select>
 		{{#select pageSize}}
-			<option value="10">{{i18n.tablePageSize.ten}}</option>
-			<option value="25">{{i18n.tablePageSize.twentyFive}}</option>
-			<option value="50">{{i18n.tablePageSize.fifty}}</option>
-			<option value="100">{{i18n.tablePageSize.hundred}}</option>
+		{{#each availablePageSizes}}
+			<option value="{{this}}">{{this}}</option>
+		{{/each}}
 		{{/select}}
 	</select>
 	<span class="label label-default">{{i18n.tablePageSize.entries}}</span>

--- a/src/apps/core/views/monster-table-paging.html
+++ b/src/apps/core/views/monster-table-paging.html
@@ -1,0 +1,20 @@
+<tr class="footable-paging">
+    <td colspan="{{cols}}">
+        <div class="footable-pagination-wrapper">
+            <ul class="pagination">
+                <li class="footable-page-nav disabled" data-page="prev">
+                    <a class="footable-page-link">‹</a>
+                </li>
+
+                <li class="footable-page visible active" data-page="1">
+                    <a class="footable-page-link" href="#">1</a>
+                </li>
+                <li class="footable-page-nav disabled" data-page="next">
+                    <a class="footable-page-link">›</a>
+                </li>
+            </ul>
+            <div class="divider"></div>
+            <span class="label label-default">1-{{rowCount}} of {{rowCount}}</span>
+        </div>
+    </td>    
+</tr>

--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -2776,7 +2776,7 @@ define(function(require) {
 				},
 				addPageSizeComponent = function(container, table, pPageSize, pAvailablePageSizes) {
 					var pageSize = pPageSize || finalOptions.paging.size || 10,
-						availablePageSizes = pAvailablePageSizes || [ 10, 25, 50, 100 ],
+						availablePageSizes = pAvailablePageSizes || finalOptions.paging.availablePageSizes,
 						footableInstance;
 
 					if (availablePageSizes.indexOf(parseInt(pageSize)) < 0) {
@@ -2788,14 +2788,29 @@ define(function(require) {
 
 					// If we gave a selector with many table, we need to add the component to each table, so we need to loop thru each table included in the jquery selector
 					$.each(table, function(k, singleTable) {
-						var $singleTable = $(singleTable);
+						var $singleTable = $(singleTable),
+							$tablePaging = $singleTable.find('.footable-paging td');
 
-						$singleTable.find('.footable-paging td').append($(monster.template(monster.apps.core, 'monster-table-pageSize', { pageSize: pageSize, availablePageSizes: availablePageSizes })));
+						if ($tablePaging.length === 0) {
+							$singleTable.find('tfoot').append(
+								$(monster.template(
+									monster.apps.core, 'monster-table-paging',
+									{
+										cols: $singleTable.find('tbody > tr:first > td').length,
+										rowCount: footable.get($singleTable).rows.all.length
+									}
+								))
+							);
+							$tablePaging = $singleTable.find('.footable-paging td');
+						}
+
+						$tablePaging.append($(monster.template(monster.apps.core, 'monster-table-pageSize', { pageSize: pageSize, availablePageSizes: availablePageSizes })));
 
 						$singleTable.find('.footable-paging td .table-page-size select').on('change', function() {
 							pageSize = parseInt($(this).val());
 							footableInstance = footable.get('#' + $singleTable.attr('id'));
 
+							$singleTable.find('tfoot').empty();
 							footableInstance.pageSize(pageSize);
 							addPageSizeComponent(container, $singleTable, pageSize, availablePageSizes);
 
@@ -2923,6 +2938,7 @@ define(function(require) {
 						enabled: true,
 						size: 10,
 						limit: 0,
+						availablePageSizes: [ 10, 25, 50, 100 ],
 						countFormat: monster.apps.core.i18n.active().footable.format
 					}
 				},


### PR DESCRIPTION
* Template used to re add paging element when footable function pageSize removes it

* Changing template to render the specified page sizes instead of hardcoded sizes

* Adding default available page sizes

* Expaning functionality to accept customs available page sizes and fixing the issue of paging element disapperaing

* Adding next and prev to paging template

* Sending row count to paging template

* Removing unused pagesizes labels from translation files