### PR TITLE
MSPB-233: don't delete tts media for non tabs mediaSelect

### DIFF
--- a/src/apps/common/submodules/mediaSelect/mediaSelect.js
+++ b/src/apps/common/submodules/mediaSelect/mediaSelect.js
@@ -269,6 +269,7 @@ define(function(require) {
 		mediaSelectGetValue: function(template, args) {
 			var self = this,
 				ttsTab = template.find('.monster-tab-content.monster-tab-content-tts.active'),
+				skin = args.hasOwnProperty('skin') ? args.skin : 'default',
 				callback = args.callback,
 				response;
 
@@ -295,7 +296,7 @@ define(function(require) {
 					response = val;
 				}
 
-				if (args.selectedMedia.media_source === 'tts' && !ttsTab.length) {
+				if (skin === 'tabs' && args.selectedMedia.media_source === 'tts' && !ttsTab.length) {
 					self.deleteTTSMedia(args.selectedMedia.id);
 				}
 			} else {


### PR DESCRIPTION
# Issue
A DELETE request was being done when updating a VMBox that has a TTS media in smartPBX.

# Demo

https://user-images.githubusercontent.com/33939096/154120288-0fadfa84-89ea-4906-b0ef-66b4ba9108b2.mov




Ticket: https://2600hz-commercial.atlassian.net/browse/MSPB-233
5.0 PR: https://github.com/2600hz/monster-ui/pull/995