### PR TITLE
[5.1] MSTR-230: Add an alpha tag and notice to marketplace pages

### DIFF
--- a/src/apps/appstore/app.js
+++ b/src/apps/appstore/app.js
@@ -502,6 +502,19 @@ define(function(require) {
 					saveThis.prop({ disabled: false });
 				}
 			});
+
+			parent.find('.market-link #cancel_disable').on('click', function(e) {
+				e.preventDefault();
+
+				self.maybeSetApiUrl();
+				self.updateMarketConnector(
+					{ action: 'disable' },
+					function() {
+						self.showMarketplaceConnector(
+							parent
+						);
+					});
+			});
 		},
 
 		renderMarketSettings: function(parent) {

--- a/src/apps/appstore/app.js
+++ b/src/apps/appstore/app.js
@@ -506,7 +506,6 @@ define(function(require) {
 			parent.find('.market-link #cancel_disable').on('click', function(e) {
 				e.preventDefault();
 
-				self.maybeSetApiUrl();
 				self.updateMarketConnector(
 					{ action: 'disable' },
 					function() {

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -29,7 +29,7 @@
 	"marketplace": {
 		"title": "Marketplace Connector",
 		"sidebarTitle": "Administrator Features",
-		"betaNotice": "2600Hz Marketplace is still in Alpha phase and is not ready for production use. Please expect some minor bugs and defects and/or limitation in features.",
+		"betaNotice": "2600Hz Marketplace is still in Alpha phase and is not fully certified for production use. Please expect some bugs and limitations in features and send us your feedback.",
 		"openToMarket": "Go to 2600Hz Marketplace",
 		"welcome": {
 			"title": "A new way to make Kazoo awesome is",

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -49,7 +49,8 @@
 			"formAccessCode": "Access Code:",
 			"formClusterName": "Name your Cluster:",
 			"formClusterId": "Cluster ID:",
-			"linkCluster": "Link your cluster"
+			"linkCluster": "Link your cluster",
+			"cancelDisable": "Cancel and Disable"
 		},
 		"edition": {
 			"subtitle": "Appex Client Configuration",

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -28,6 +28,7 @@
 	},
 	"marketplace": {
 		"title": "Marketplace Connector",
+		"betaNotice": "2600Hz Marketplace is still in Alpha phase and is not ready for production use. Please expect some minor bugs and defects and/or limitation in features.",
 		"openToMarket": "Go to 2600Hz Marketplace",
 		"welcome": {
 			"title": "A new way to make Kazoo awesome is",

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -28,6 +28,7 @@
 	},
 	"marketplace": {
 		"title": "Marketplace Connector",
+		"sidebarTitle": "Administrator Features",
 		"betaNotice": "2600Hz Marketplace is still in Alpha phase and is not ready for production use. Please expect some minor bugs and defects and/or limitation in features.",
 		"openToMarket": "Go to 2600Hz Marketplace",
 		"welcome": {

--- a/src/apps/appstore/style/app.scss
+++ b/src/apps/appstore/style/app.scss
@@ -255,6 +255,20 @@
 	font-size: 12px;
 }
 
+#appstore_container .market-beta-notice {
+	margin: 0 auto 25px;
+	padding: 24px;
+
+	background-color: #c6d9fc;
+	border-radius: 2px;
+	font-size: 16px;
+
+	i.fa-info-circle {
+		margin-right: 10px;
+		color: #3478f5;
+		font-size: 18px;
+	}
+}
 
 #appstore_container #market-content {
 	border: 1px solid #e0e0e9;

--- a/src/apps/appstore/style/app.scss
+++ b/src/apps/appstore/style/app.scss
@@ -74,16 +74,24 @@
 }
 
 #appstore_container .left-menu .marketplace {
+	margin: 24px auto;
+
+	.admin-title {
+		color: #a4a4ab;
+		font-weight: bold;
+		padding-left: 4px;
+	}
 	.launch-market {
-		margin: 15px auto;
+		position: relative;
+		margin: 8px auto;
 		padding: 15px 10px;
 
-		background: #47C1BF;
+		background: #f4f4f5;
+		border: 1px solid #bcbcc2;
 		border-radius: 4px;
-		color: white;
 
 		cursor: pointer;
-		font-size: 16px;
+		font-size: 15px;
 		height: 36px;
 		line-height: 36px;
 		overflow: hidden;
@@ -91,13 +99,35 @@
 		text-overflow: ellipsis;
 	}
 
+	.launch-market::after {
+		position: absolute;
+		content: 'Alpha';
+		bottom: 10px;
+		right: -58px;
+		width: 150px;
+		height: 18px;
+		line-height: 18px;
+		overflow: hidden;
+
+		background-color: #ff3d24;
+		border: 1px solid white;
+		color: #fff;
+		text-align: center;
+		text-transform: uppercase;
+		font-size: 12px;
+		font-weight: bold;
+
+		transform: rotate(315deg);
+		box-shadow: 1px 1px 1px rgba(49, 49, 58, .6);
+	}
+
 	.launch-market:hover {
-		background: #2F8A89;
-		border-radius: 4px;
+		background: #2297ff;
+		border-color: #006bca;
 	}
 	.launch-market.active {
-		background: #2F8A89;
-		border-radius: 4px;
+		background: #2297ff;
+		border-color: #006bca;
 	}
 
 	.title {

--- a/src/apps/appstore/style/app.scss
+++ b/src/apps/appstore/style/app.scss
@@ -256,18 +256,8 @@
 }
 
 #appstore_container .market-beta-notice {
-	margin: 0 auto 25px;
-	padding: 24px;
-
-	background-color: #c6d9fc;
-	border-radius: 2px;
-	font-size: 16px;
-
-	i.fa-info-circle {
-		margin-right: 10px;
-		color: #3478f5;
-		font-size: 18px;
-	}
+	padding: 2px;
+	overflow: hidden;
 }
 
 #appstore_container #market-content {

--- a/src/apps/appstore/style/app.scss
+++ b/src/apps/appstore/style/app.scss
@@ -109,7 +109,7 @@
 		line-height: 18px;
 		overflow: hidden;
 
-		background-color: #ff3d24;
+		background-color: $red-orange;
 		border: 1px solid white;
 		color: #fff;
 		text-align: center;
@@ -117,17 +117,17 @@
 		font-size: 12px;
 		font-weight: bold;
 
-		transform: rotate(315deg);
+		transform: rotate(-45deg);
 		box-shadow: 1px 1px 1px rgba(49, 49, 58, .6);
 	}
 
 	.launch-market:hover {
-		background: #2297ff;
-		border-color: #006bca;
+		background: $primary-color;
+		border-color: darken($primary-color, 20%);
 	}
 	.launch-market.active {
-		background: #2297ff;
-		border-color: #006bca;
+		background: $primary-color;
+		border-color: darken($primary-color, 20%);
 	}
 
 	.title {
@@ -139,7 +139,6 @@
 		i {
 			margin: 0 8px 0 4px;
 			font-size: 16px;
-			// color: #2F8A89;
 			color: white;
 		}
 	}

--- a/src/apps/appstore/views/app.html
+++ b/src/apps/appstore/views/app.html
@@ -37,7 +37,7 @@
 		{{#if shouldShowMarket }}
 		<div class="marketplace">
 			<div class="admin-title">
-				Administrator Features
+				{{ i18n.marketplace.sidebarTitle }}
 			</div>
 			<div class="launch-market">
 				<div class="title">

--- a/src/apps/appstore/views/app.html
+++ b/src/apps/appstore/views/app.html
@@ -36,6 +36,9 @@
 		</div>
 		{{#if shouldShowMarket }}
 		<div class="marketplace">
+			<div class="admin-title">
+				Administrator Features
+			</div>
 			<div class="launch-market">
 				<div class="title">
 					{{ i18n.marketplace.title }}

--- a/src/apps/appstore/views/marketClusterLink.html
+++ b/src/apps/appstore/views/marketClusterLink.html
@@ -1,3 +1,6 @@
+<div class="market-beta-notice">
+	<i class="fa fa-info-circle"></i> {{ i18n.marketplace.betaNotice }}
+</div>
 <div id="market-content">
 	<div class="market-header">
 		<img alt="marketplace illustration" src="apps/appstore/style/static/images/explore_marketplace.png" />

--- a/src/apps/appstore/views/marketClusterLink.html
+++ b/src/apps/appstore/views/marketClusterLink.html
@@ -1,5 +1,7 @@
 <div class="market-beta-notice">
-	<i class="fa fa-info-circle"></i> {{ i18n.marketplace.betaNotice }}
+	{{#monsterPanelText "Alpha notice" "info" "fill-width"}}
+		{{ i18n.marketplace.betaNotice }}
+	{{/monsterPanelText}}
 </div>
 <div id="market-content">
 	<div class="market-header">

--- a/src/apps/appstore/views/marketClusterLink.html
+++ b/src/apps/appstore/views/marketClusterLink.html
@@ -38,6 +38,9 @@
 					</div>
 				</div>
 				<div class="control-group control-actions clearfix">
+					<button id="cancel_disable" type="submit" class="monster-button monster-button-neutral">
+						{{ i18n.marketplace.linkage.cancelDisable }}
+					</button>
 					<div class="pull-right">
 						<button id="save" type="submit" class="monster-button monster-button-success">
 							{{ i18n.marketplace.linkage.linkCluster }}

--- a/src/apps/appstore/views/marketConnectorSettings.html
+++ b/src/apps/appstore/views/marketConnectorSettings.html
@@ -1,3 +1,6 @@
+<div class="market-beta-notice">
+	<i class="fa fa-info-circle"></i> {{ i18n.marketplace.betaNotice }}
+</div>
 <div id="market-content">
 	<div class="market-settings">
 		<div class="header-form">

--- a/src/apps/appstore/views/marketConnectorSettings.html
+++ b/src/apps/appstore/views/marketConnectorSettings.html
@@ -1,5 +1,7 @@
 <div class="market-beta-notice">
-	<i class="fa fa-info-circle"></i> {{ i18n.marketplace.betaNotice }}
+	{{#monsterPanelText "Alpha notice" "info" "fill-width"}}
+		{{ i18n.marketplace.betaNotice }}
+	{{/monsterPanelText}}
 </div>
 <div id="market-content">
 	<div class="market-settings">

--- a/src/apps/appstore/views/marketWelcome.html
+++ b/src/apps/appstore/views/marketWelcome.html
@@ -1,3 +1,6 @@
+<div class="market-beta-notice">
+	<i class="fa fa-info-circle"></i> {{ i18n.marketplace.betaNotice }}
+</div>
 <div id="market-content">
 	<div class="market-header">
 		<img alt="marketplace illustration" src="apps/appstore/style/static/images/explore_marketplace.png" />

--- a/src/apps/appstore/views/marketWelcome.html
+++ b/src/apps/appstore/views/marketWelcome.html
@@ -1,5 +1,7 @@
 <div class="market-beta-notice">
-	<i class="fa fa-info-circle"></i> {{ i18n.marketplace.betaNotice }}
+	{{#monsterPanelText "Alpha notice" "info" "fill-width"}}
+		{{ i18n.marketplace.betaNotice }}
+	{{/monsterPanelText}}
 </div>
 <div id="market-content">
 	<div class="market-header">


### PR DESCRIPTION
This adds some notices indicating the app marketplace is in alpha phase.

Also it adds the ability to cancel and disable marketplace connector from Cluster Link step and go back to welcome screen.

* adding alpha ribbon to connector button on left side (normal mode):
![image](https://user-images.githubusercontent.com/4894215/180580416-eb284201-43b8-4a8e-9936-41e61c390d4d.png)

* adding alpha ribbon to connector button on left side (hove mode mode):
![image](https://user-images.githubusercontent.com/4894215/180580465-6a33a00a-fe2b-4ebf-8f08-a0e7a92e995a.png)

* notices in marketplace connector pages:
﻿ ![image](https://user-images.githubusercontent.com/4894215/180617050-e42a2207-48bf-4428-af3a-031e8b516aa0.png)


* cancel and disable button at the bottom of cluster link page:
![image](https://user-images.githubusercontent.com/4894215/180580531-14e47eff-684a-40ba-9ed0-8aa3f16b219e.png)