### PR TITLE
MGDC-3: Pattern used in crossroads is no longer trimming app names with more than one hyphen

### DIFF
--- a/src/js/lib/monster.routing.js
+++ b/src/js/lib/monster.routing.js
@@ -104,7 +104,7 @@ define(function(require) {
 		},
 
 		addDefaultRoutes: function() {
-			this.add(/^apps\/([a-z]+(?:-[a-z]+)?)(\/[^?]*)?\??(.*)?$/, function(appName, restSegment, queryString) {
+			this.add(/^apps\/([a-z]+(?:-[a-z]+)*)(\/[^?]*)?\??(.*)?$/, function(appName, restSegment, queryString) {
 				// not logged in, do nothing to preserve potentially valid route to load after successful login
 				if (!monster.util.isLoggedIn()) {
 					return;


### PR DESCRIPTION
…more than one hyphen

Current pattern provided to crossroads.addRouter to extract appName from url is trimming values such as `service-plan-assignment` and `integration-google-drive`, due to it stops after first hyphen, so for example `integration-google-drive` becomes `integration-google`.
Apps affected by this issue
- Service Plan Assignment
- Service Plan Override
- One Bill Integration
- Google Drive Connector