### PR TITLE
MSPB-295,MSPB-296: Pass the trigger element to the clipboard callback

### DIFF
--- a/src/js/lib/monster.ui.js
+++ b/src/js/lib/monster.ui.js
@@ -3328,22 +3328,22 @@ define(function(require) {
 			}
 		},
 
-		clipboard: function(pTarget, value) {
+		clipboard: function(pTarget, value, successMessage) {
 			// Have to do this so it works...
 			$.ui.dialog.prototype._focusTabbable = $.noop;
 
 			var target = pTarget[0];
 
 			var cb = new Clipboard(target, {
-				text: function() {
-					return typeof value === 'function' ? value() : value;
+				text: function(trigger) {
+					return typeof value === 'function' ? value(trigger) : value;
 				}
 			});
 
 			cb.on('success', function() {
 				toast({
 					type: 'success',
-					message: monster.apps.core.i18n.active().clipboard.successCopy
+					message: successMessage || monster.apps.core.i18n.active().clipboard.successCopy
 				});
 			});
 		},


### PR DESCRIPTION
Pass the element that triggers `clipboard` click events to the invoking callback in order to access their custom `dataset` attributes for copying purposes
Show a custom success message if needed but fallback to the previous one if none is provided