### PR TITLE
OOB: Implement capped exponential backoff on WS reconnect

### DIFF
--- a/src/js/lib/monster.socket.js
+++ b/src/js/lib/monster.socket.js
@@ -243,8 +243,8 @@ define(function(require) {
 		 */
 		this.handshakes = new Handshakes();
 
-		this.MAX_RECONNECT_DELAY_IN_MILLISECONDS = 60 * 1000;
-		this.RECONNECT_BACKOFF_IN_MILLISECONDS = 125;
+		this.MAX_RECONNECT_DELAY_IN_MILLISECONDS = 10 * 1000;
+		this.RECONNECT_BACKOFF_IN_MILLISECONDS = 250;
 	}
 	WebSocketClient.prototype = {
 		/**


### PR DESCRIPTION
- Extract reconnect constants as instance variables
- Implement exponential backoff reconnect strategy
- Update reconnect default delay timers

The goal of this PR is to formalize the WebSocket reconnect strategy and give us the ability to logically reason about the underlying algorithm, which can prove invaluable and save time when debugging.

The reconnect strategy implements a backoff algorithm, more specifically it makes use of **capped exponential backoff** with jitter. The delay for the first reconnect is .250 second, which grows exponentially in relation with the current number of attempts, until it reaches and gets capped at 10 seconds. To avoid reconnect retry storms, where waves of clients loose connection at about the same time and hammer the WebSocket service, the concept of jitter is added to the mix. Jitter introduces randomness in the reconnect delay calculation, to spread out retries over time and smooth out the load. More in-depth information about this algorithm can be found [here](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/#:~:text=Capped%20exponential%20backoff%20means%20that,doesn't%20solve%20the%20problem.).

Note that no max attempts threshold/[circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) mechanism was added, and clients will continue reconnecting until successful or until a user navigates away from an application requiring real-time data.