### PR TITLE
MACF-76: Fix Time Of Day Increment When Saving

### DIFF
--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -17,6 +17,7 @@ define(function(require) {
 		dataFlags: getDataFlagsManager(),
 		dateToBeginningOfGregorianDay: dateToBeginningOfGregorianDay,
 		dateToEndOfGregorianDay: dateToEndOfGregorianDay,
+		validateEndOrBeginingOfGregorianDay: validateEndOrBeginingOfGregorianDay,
 		dateToGregorian: dateToGregorian,
 		dateToUnix: dateToUnix,
 		findCallflowNode: findCallflowNode,
@@ -250,6 +251,21 @@ define(function(require) {
 		return a > b ? 1
 			: a < b ? -1
 			: 0;
+	}
+
+	/**
+	 * @param {Date} date Date to convert to gregorian.
+	 * @param {String} [timezone] Timezone to set date in.
+	 * @param {String} [timezone] Timezone to validate UTC offset
+	 * @returns {Number} Gregoian timestamp to either begining or end of day.
+	 */
+	function validateEndOrBeginingOfGregorianDay(date, pTimezone, userTz) {
+		var tz = _.isNull(moment.tz.zone(userTz)) ? getCurrentTimeZone() : userTz;
+		if (moment.tz(tz).utcOffset() > 0) {
+			return dateToBeginningOfGregorianDay(date, pTimezone);
+		} else {
+			return dateToEndOfGregorianDay(date, pTimezone);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Creating new function `validateEndOrBegeningOfGregorianDay` to validate if date should be saved at the end of begining of gregorian date to avoid the issue where the saved date could apper as a fay before or after the one set on Time of Day edit on CallFlows due tu timezone hour offsets.

Related CallFlows PR: https://github.com/2600hz/monster-ui-callflows/pull/236