### PR TITLE
MCON-19: Fix issue with conferences due to changes in the API response

### DIFF
--- a/src/apps/common/submodules/conferenceViewer/conferenceViewer.js
+++ b/src/apps/common/submodules/conferenceViewer/conferenceViewer.js
@@ -119,6 +119,10 @@ define(function(require) {
 					conferenceId: conferenceId
 				},
 				success: function(data) {
+					var conferenceData = _.merge({}, data.data, {
+						metadata: data.metadata
+					});
+
 					callback && callback(data.data);
 				}
 			});
@@ -257,8 +261,8 @@ define(function(require) {
 			return {
 				backButton: args.backButton,
 				conference: _.merge({
-					duration: data.conference._read_only.duration,
-					isLocked: data.conference._read_only.is_locked,
+					duration: data.conference.metadata.duration,
+					isLocked: data.conference.metadata.is_locked,
 					participants: participants,
 					moderators: moderators
 				}, _.pick(data.conference, [

--- a/src/apps/common/submodules/conferenceViewer/conferenceViewer.js
+++ b/src/apps/common/submodules/conferenceViewer/conferenceViewer.js
@@ -123,7 +123,7 @@ define(function(require) {
 						metadata: data.metadata
 					});
 
-					callback && callback(data.data);
+					callback && callback(conferenceData);
 				}
 			});
 		},


### PR DESCRIPTION
The issue is that in 5.1 we used to get `data._read_only`
<img width="606" alt="5 1" src="https://user-images.githubusercontent.com/16088958/229187929-ff34b260-5ad1-48af-8055-fedadc81b114.png">


And now in 5.2, the API response is different, now we need to get `metadata` for some values:
<img width="786" alt="5 2" src="https://user-images.githubusercontent.com/16088958/229188130-accb23af-88e0-42e3-ba8d-d74837e67c9f.png">

