### PR TITLE
[5.1] MSTR-273: Preserve leading zeros in extension numbers

### DIFF
--- a/src/apps/common/submodules/extensionTools/extensionTools.js
+++ b/src/apps/common/submodules/extensionTools/extensionTools.js
@@ -50,7 +50,10 @@ define(function(require) {
 						parsedNumber = parseInt(number);
 
 						if (parsedNumber && parsedNumber > 0 && parsedNumber < 100000) {
-							formattedData.extensions.push({ extension: parsedNumber, callflow: callflow.name || self.i18n.active().extensionTools.getNew.table.unNamedCallflow });
+							formattedData.extensions.push({
+								extension: number,
+								callflow: callflow.name || self.i18n.active().extensionTools.getNew.table.unNamedCallflow
+							});
 						}
 					});
 				});

--- a/src/apps/common/submodules/extensionTools/views/getNewDialog.html
+++ b/src/apps/common/submodules/extensionTools/views/getNewDialog.html
@@ -12,7 +12,7 @@
 		<table id="extension_listing_dialog_table" class="monster-table monster-table-skinny footable ">
 			<thead>
 				<tr class="footable-header">
-					<th data-type="number">{{i18n.extensionTools.getNew.table.columns.extension}}</th>
+					<th data-type="text">{{i18n.extensionTools.getNew.table.columns.extension}}</th>
 					<th data-breakpoints="xs">{{i18n.extensionTools.getNew.table.columns.callflowName}}</th>
 				</tr>
 			</thead>


### PR DESCRIPTION
Revised data processing to use the unaltered `number` variable instead of `parsedNumber`, as `parseInt()` automatically removes any leading zeros, and altered the HTML table column data type from `number` to `text` to counteract HTML's numerical data design which also strips leading zeros, thereby ensuring the preservation of leading zeros in extension numbers