### PR TITLE
[5.3] MSTR-270: adding new view to show when cluster was unlinked from portal and then return error when entering on monster ui

### DIFF
--- a/src/apps/appstore/app.js
+++ b/src/apps/appstore/app.js
@@ -92,6 +92,17 @@ define(function(require) {
 
 						marketplaceActive = true;
 						self.showMarketplaceConnector(parent);
+					},
+					function(error) {
+						/* checking for the error returned when cluster is unlinked from portal
+						an then log into monster ui*/
+						if (error.status === 500 && error.data.name === 'Unauthorized') {
+							/* if this is not true the left items won't do anything*/
+							marketplaceActive = true;
+							self.renderMarketUnLinkedCluster(parent);
+						} else {
+							self.showErrorDialog(error);
+						}
 					});
 				});
 			}
@@ -516,6 +527,39 @@ define(function(require) {
 			});
 		},
 
+		renderMarketUnLinkedCluster: function(parent) {
+			const self = this;
+			const template = $(self.getTemplate({
+				name: 'marketUnlinkedCluster'
+			}));
+
+			monster.ui.insertTemplate(parent.find('.right-container'), template);
+			self.bindUnlinckClusterEvents();
+		},
+
+		bindUnlinckClusterEvents: function() {
+			var self = this;
+			$('#complete-unlink').on('click', function() {
+				self.updateMarketConnector({ action: 'unlink' }, function() {
+					window.location = window.location.pathname;
+				});
+			});
+		},
+
+		showErrorDialog: function(error) {
+			var self = this;
+			monster.ui.requestErrorDialog({
+				data: {
+					status: error.status,
+					message: self.i18n.active().errors.generic,
+					requestId: error.requestId || '',
+					response: error.responseText ? JSON.stringify($.parseJSON(error.responseText), null, 4) : JSON.stringify(error, null, 4),
+					url: error.monsterData.url,
+					verb: error.monsterData.verb,
+					jsonResponse: error.responseText ? $.parseJSON(error.responseText) : error }
+			});
+		},
+
 		renderMarketSettings: function(parent) {
 			const self = this;
 			const marketConfig = self.getStore('marketConfig');
@@ -693,6 +737,7 @@ define(function(require) {
 			// onSuccess()
 			monster.request({
 				resource: 'marketplace.get',
+				generateError: false,
 				success: function(response) {
 					if (response && response.data) {
 						self.setStore('marketConfig', response.data);

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -89,8 +89,8 @@
 			"content": "This will disable the Marketplace connector. The next time your KAZOO nodes start, apps purchased through the Marketplace will not be started. Do not forget to also remove those applications from your Kazoo nodes start up list."
 		},
 		"unlinkedCluster": {
-			"mainText": "Hey, if you unliked your cluster using the marketplace portal",
-			"buttonText":"Click here to cleanup cluster link state in your cluster"
+			"mainText": "Hmmm. We are currently unable to access the Marketplace Connector app. It appears your cluster was disconnected using your Marketplace Account's disconnection routine. To restore the Connector app and access the Cluster Connection page, please select the button below. You will then need to restart the cluster connection process from the Marketplace.",
+			"buttonText":"Complete Unlinking"
 		}
 	},
 	"selectedUsers": "Selected Users",

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -88,7 +88,7 @@
 		"dangerDisableDialog": {
 			"content": "This will disable the Marketplace connector. The next time your KAZOO nodes start, apps purchased through the Marketplace will not be started. Do not forget to also remove those applications from your Kazoo nodes start up list."
 		},
-		"ulinkedCluster": {
+		"unlinkedCluster": {
 			"mainText": "Hey, if you unliked your cluster using the marketplace portal",
 			"buttonText":"Click here to cleanup cluster link state in your cluster"
 		}

--- a/src/apps/appstore/i18n/en-US.json
+++ b/src/apps/appstore/i18n/en-US.json
@@ -87,6 +87,10 @@
 		},
 		"dangerDisableDialog": {
 			"content": "This will disable the Marketplace connector. The next time your KAZOO nodes start, apps purchased through the Marketplace will not be started. Do not forget to also remove those applications from your Kazoo nodes start up list."
+		},
+		"ulinkedCluster": {
+			"mainText": "Hey, if you unliked your cluster using the marketplace portal",
+			"buttonText":"Click here to cleanup cluster link state in your cluster"
 		}
 	},
 	"selectedUsers": "Selected Users",

--- a/src/apps/appstore/views/marketUnlinkedCluster.html
+++ b/src/apps/appstore/views/marketUnlinkedCluster.html
@@ -1,0 +1,12 @@
+<div id="market-content">
+    <div class="market-welcome">
+		<div class="market-body">
+			<p class="lead">{{i18n.marketplace.unlinkedCluster.mainText}}</p>
+			<div class="actions">
+                <button id="complete-unlink" class="monster-button monster-button-primary">
+                    {{i18n.marketplace.unlinkedCluster.buttonText}}
+				</button>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
handling when monsterui marketplace connector returns 401 error from appex-server when we open connector and showing a view to complete the unlinking process and then return to the link cluster view.


![Captura de pantalla 2023-12-21 101808](https://github.com/2600hz/monster-ui/assets/26661843/09d63dca-9cf6-4d79-a285-6828a4c0adef)
