### PR TITLE
[5.3] MSPB-352: Fix e911 Erasure on Account CallerID Selection via SmartPBX

### DIFF
--- a/src/js/lib/monster.util.js
+++ b/src/js/lib/monster.util.js
@@ -1167,8 +1167,8 @@ define(function(require) {
 			throw new TypeError('"number" is not an object');
 		}
 		var pathToFeatures = _.find([
-			'_read_only.features.available',
-			'features_available'
+			'metadata.features.available',
+			'features'
 		], function(path) {
 			return _.has(number, path);
 		});


### PR DESCRIPTION
The `pathToFeatures` snippet has been updated to utilize the newly introduced "metadata" field in Kazoo 5.3, along with an improved mapping of `features`