### PR TITLE
[5.3] MSTR-327: Fix Payment Method Pop-up After Successful ACH Setup

### DIFF
--- a/src/apps/myaccount/submodules/billing/billing.js
+++ b/src/apps/myaccount/submodules/billing/billing.js
@@ -481,7 +481,7 @@ define(function(require) {
 						return next(null, mainData);
 					}
 
-					self.getPaymentMethods({
+					self.billingGetPaymentMethods({
 						success: function(payments) {
 							next(null, _.assign({}, mainData, { payments: payments }));
 						},
@@ -644,7 +644,7 @@ define(function(require) {
 
 					monster.waterfall([
 						function reloadPaymentMethods(next) {
-							self.getPaymentMethods({
+							self.billingGetPaymentMethods({
 								success: function(payments) {
 									next(null, payments);
 								},
@@ -1144,7 +1144,7 @@ define(function(require) {
 			});
 		},
 
-		getPaymentMethods: function(args) {
+		billingGetPaymentMethods: function(args) {
 			var self = this;
 
 			monster.request({

--- a/src/apps/myaccount/submodules/creditCard/creditCard.js
+++ b/src/apps/myaccount/submodules/creditCard/creditCard.js
@@ -576,21 +576,7 @@ define(function(require) {
 						}
 					});
 				},
-				billing: function(next) {
-					self.callApi({
-						resource: 'billing.get',
-						data: {
-							accountId: self.accountId,
-							generateError: false
-						},
-						success: function(data) {
-							next(null, data.data);
-						},
-						error: function() {
-							next(true);
-						}
-					});
-				}
+				billing: _.bind(self.billingGetBillingData, self)
 			}, function(err, results) {
 				if (err) {
 					return;
@@ -599,12 +585,12 @@ define(function(require) {
 				var account = results.account,
 					billing = results.billing,
 					isSurchargeAccepted = self.billingIsSurchargeAccepted(account),
-					hasCreditCards = !_.chain(billing).get('credit_cards', []).isEmpty().value(),
+					hasCreditCards = !_.chain(billing).get('customer.credit_cards', []).isEmpty().value(),
 					country = _.get(account, ['contact', 'billing', 'country']),
 					region = _.get(account, ['contact', 'billing', 'region']),
 					surcharge = self.billingGetCreditCardSurcharge(country, region),
 					isCardAccepted = !!surcharge,
-					hasVerifiedACH = _.chain(billing).get('payments', []).some({ 'type': 'ach', 'verified': true }).value();
+					hasVerifiedACH = _.chain(billing).get('payments', []).some({ type: 'ach', verified: true, 'default': true }).value();
 
 				if (
 					!hasCreditCards || country !== 'US' || (isCardAccepted && isSurchargeAccepted) || hasVerifiedACH) {

--- a/src/apps/myaccount/submodules/creditCard/creditCard.js
+++ b/src/apps/myaccount/submodules/creditCard/creditCard.js
@@ -603,9 +603,11 @@ define(function(require) {
 					country = _.get(account, ['contact', 'billing', 'country']),
 					region = _.get(account, ['contact', 'billing', 'region']),
 					surcharge = self.billingGetCreditCardSurcharge(country, region),
-					isCardAccepted = !!surcharge;
+					isCardAccepted = !!surcharge,
+					hasVerifiedACH = _.chain(billing).get('payments', []).some({ 'type': 'ach', 'verified': true }).value();
 
-				if (!hasCreditCards || country !== 'US' || (isCardAccepted && isSurchargeAccepted)) {
+				if (
+					!hasCreditCards || country !== 'US' || (isCardAccepted && isSurchargeAccepted) || hasVerifiedACH) {
 					return;
 				}
 


### PR DESCRIPTION
- Added `hasVerifiedACH` check to prevent the payment method pop-up after successful ACH setup.
- Ensured the pop-up triggers only when necessary conditions are unmet.