### PR TITLE
MSPB-385: Add `nl-BE` language and `tts.voice` `whitelabel` support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,7 @@ Key | Description | Type | Default | Required
 `useDropdownApploader` | If set to true, the apploader will render as a dropdown list instead of a page on top of the window. False by default. | `Boolean` | `false` | `false`
 `disableFirstUseWalkthrough` | If set to true, the new user walkthrough will not be displayed. False by default. | `Boolean` | `false` | `false`
 `invoiceRangeConfig` | The range of months one can navigate back to for the invoices in the Invoice Generator. Its default value is 6 months from the current month, but it is not required to have a value assigned to it | `Number` | `6` | `false`
+`ttsVoice` | The default Text-to-Speech voice to use throughout the platform. Format should be 'gender/language', for example 'female/en-US' or 'male/fr-FR'. | `String` | `female/en-US` | `false`
 
 #### `acceptCharges`
 

--- a/src/apps/common/submodules/mediaSelect/mediaSelect.js
+++ b/src/apps/common/submodules/mediaSelect/mediaSelect.js
@@ -491,7 +491,7 @@ define(function(require) {
 					type: _.get(args, 'tts.type', ''),
 					tts: {
 						text: args.selectedMedia.tts.text,
-						voice: 'female/en-US'
+						voice: monster.config.whitelabel.ttsVoice || monster.defaultTTSVoice
 					}
 				};
 

--- a/src/apps/core/i18n/de-DE.json
+++ b/src/apps/core/i18n/de-DE.json
@@ -178,7 +178,8 @@
 		"canadianFrench": "Französisch (fr-CA)",
 		"__comment": "Spanisch zur Sprachauswahlliste in Mein Account hinzugefügt",
 		"__version": "v3.22",
-		"spainSpanish": "Spanisch (es-ES)"
+		"spainSpanish": "Spanisch (es-ES)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"cnam": "CNAM",

--- a/src/apps/core/i18n/de-DE.json
+++ b/src/apps/core/i18n/de-DE.json
@@ -1029,7 +1029,8 @@
 		"es-ES": "Spanisch (es-ES)",
 		"fr-FR": "Französisch (fr-FR)",
 		"nl-NL": "Niederländisch (nl-NL)",
-		"ru-RU": "Russisch (ru-RU)"
+		"ru-RU": "Russisch (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	},
 
 	"nav": {

--- a/src/apps/core/i18n/en-GB.json
+++ b/src/apps/core/i18n/en-GB.json
@@ -1108,7 +1108,8 @@
 		"es-ES": "Spanish (es-ES)",
 		"fr-FR": "French (fr-FR)",
 		"nl-NL": "Dutch (nl-NL)",
-		"ru-RU": "Russian (ru-RU)"
+		"ru-RU": "Russian (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	},
 	"chosen": {
 		"addNewTag": "Hit enter to add a new option."

--- a/src/apps/core/i18n/en-GB.json
+++ b/src/apps/core/i18n/en-GB.json
@@ -225,7 +225,8 @@
 		"canadianFrench": "French (fr-CA)",
 		"__comment": "Add Spanish to the list of selectable languages in My Account",
 		"__version": "v3.22",
-		"spainSpanish": "Spanish (es-ES)"
+		"spainSpanish": "Spanish (es-ES)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"cnam": "CNAM",

--- a/src/apps/core/i18n/en-US.json
+++ b/src/apps/core/i18n/en-US.json
@@ -1108,7 +1108,8 @@
 		"es-ES": "Spanish (es-ES)",
 		"fr-FR": "French (fr-FR)",
 		"nl-NL": "Dutch (nl-NL)",
-		"ru-RU": "Russian (ru-RU)"
+		"ru-RU": "Russian (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	},
 	"chosen": {
 		"addNewTag": "Hit enter to add a new option."

--- a/src/apps/core/i18n/en-US.json
+++ b/src/apps/core/i18n/en-US.json
@@ -225,7 +225,8 @@
 		"canadianFrench": "French (fr-CA)",
 		"__comment": "Add Spanish to the list of selectable languages in My Account",
 		"__version": "v3.22",
-		"spainSpanish": "Spanish (es-ES)"
+		"spainSpanish": "Spanish (es-ES)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"cnam": "CNAM",

--- a/src/apps/core/i18n/fr-CA.json
+++ b/src/apps/core/i18n/fr-CA.json
@@ -147,7 +147,8 @@
 		"germanGerman": "Allemand (de-DE)",
 		"spainSpanish": "Espagnol (es-ES)",
 		"britishEnglish": "Anglais (en-GB)",
-		"canadianFrench": "Français (fr-CA)"
+		"canadianFrench": "Français (fr-CA)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"twoway_trunks": "Twoway Trunks",

--- a/src/apps/core/i18n/fr-CA.json
+++ b/src/apps/core/i18n/fr-CA.json
@@ -611,6 +611,7 @@
 		"es-ES": "Espagnol (es-ES)",
 		"fr-FR": "Français (fr-FR)",
 		"nl-NL": "Néerlandais (nl-NL)",
-		"ru-RU": "Russe (ru-RU)"
+		"ru-RU": "Russe (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	}
 }

--- a/src/apps/core/i18n/fr-FR.json
+++ b/src/apps/core/i18n/fr-FR.json
@@ -147,7 +147,8 @@
 		"germanGerman": "Allemand (de-DE)",
 		"spainSpanish": "Espagnol (es-ES)",
 		"britishEnglish": "Anglais (en-GB)",
-		"canadianFrench": "Français (fr-CA)"
+		"canadianFrench": "Français (fr-CA)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"twoway_trunks": "Twoway Trunks",

--- a/src/apps/core/i18n/fr-FR.json
+++ b/src/apps/core/i18n/fr-FR.json
@@ -611,6 +611,7 @@
 		"es-ES": "Espagnol (es-ES)",
 		"fr-FR": "Français (fr-FR)",
 		"nl-NL": "Néerlandais (nl-NL)",
-		"ru-RU": "Russe (ru-RU)"
+		"ru-RU": "Russe (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	}
 }

--- a/src/apps/core/i18n/nl-NL.json
+++ b/src/apps/core/i18n/nl-NL.json
@@ -144,7 +144,8 @@
 		"americanEnglish": "English (en-US)",
 		"dutchDUTCH": "Dutch (NL-NL)",
 		"frenchFrench": "French (fr-FR)",
-		"russianRussian": "Russian (ru-RU)"
+		"russianRussian": "Russian (ru-RU)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"cnam": "CNAM",

--- a/src/apps/core/i18n/nl-NL.json
+++ b/src/apps/core/i18n/nl-NL.json
@@ -274,6 +274,7 @@
 		"es-ES": "Spaans (es-ES)",
 		"fr-FR": "Frans (fr-FR)",
 		"nl-NL": "Nederlands (nl-NL)",
-		"ru-RU": "Russisch (ru-RU)"
+		"ru-RU": "Russisch (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	}
 }

--- a/src/apps/core/i18n/ru-RU.json
+++ b/src/apps/core/i18n/ru-RU.json
@@ -138,7 +138,8 @@
 		"germanGerman": "Немецкий (de-DE)",
 		"spanishSpain": "испанский (es-ES)",
 		"britishEnglish": "Английский (en-GB)",
-		"canadianFrench": "Французский (fr-CA)"
+		"canadianFrench": "Французский (fr-CA)",
+		"dutchBelgium": "Dutch (nl-BE)"
 	},
 	"services": {
 		"cnam": "CNAM",

--- a/src/apps/core/i18n/ru-RU.json
+++ b/src/apps/core/i18n/ru-RU.json
@@ -503,6 +503,7 @@
 		"es-ES": "Spanish (es-ES)",
 		"fr-FR": "French (fr-FR)",
 		"nl-NL": "Dutch (nl-NL)",
-		"ru-RU": "Russian (ru-RU)"
+		"ru-RU": "Russian (ru-RU)",
+		"nl-BE": "Dutch (Belgium)"
 	}
 }

--- a/src/apps/myaccount/submodules/account/views/layout.html
+++ b/src/apps/myaccount/submodules/account/views/layout.html
@@ -144,6 +144,7 @@
 										<option value="de-DE"{{#compare account.language '===' 'de-DE'}} selected{{/compare}}>{{i18n.languages.germanGerman}}</option>
 										<option value="ru-RU"{{#compare account.language '===' 'ru-RU'}} selected{{/compare}}>{{i18n.languages.russianRussian}}</option>
 										<option value="es-ES"{{#compare account.language '===' 'es-ES'}} selected{{/compare}}>{{i18n.languages.spanishSpain}}</option>
+										<option value="nl-BE"{{#compare account.language '===' 'nl-BE'}} selected{{/compare}}>{{i18n.languages.dutchBelgium}}</option>
 									</select>
 								</div>
 							</div>

--- a/src/apps/myaccount/submodules/user/views/layout.html
+++ b/src/apps/myaccount/submodules/user/views/layout.html
@@ -105,6 +105,7 @@
 										<option value="de-DE"{{#compare user.language '===' 'de-DE'}} selected{{/compare}}>{{i18n.languages.germanGerman}}</option>
 										<option value="ru-RU"{{#compare user.language '===' 'ru-RU'}} selected{{/compare}}>{{i18n.languages.russianRussian}}</option>
 										<option value="es-ES"{{#compare user.language '===' 'es-ES'}} selected{{/compare}}>{{i18n.languages.spanishSpain}}</option>
+										<option value="nl-BE"{{#compare user.language '===' 'nl-BE'}} selected{{/compare}}>{{i18n.languages.dutchBelgium}}</option>
 									</select>
 								</div>
 							</div>

--- a/src/js/lib/monster.js
+++ b/src/js/lib/monster.js
@@ -16,6 +16,7 @@ define(function(require) {
 	var defaultCountryCode = 'US';
 	var defaultCurrencyCode = 'USD';
 	var defaultLanguage = 'en-US';
+	var defaultTTSVoice = 'female/en-US';
 
 	var supportedLanguages = [
 		'de-DE',
@@ -57,7 +58,8 @@ define(function(require) {
 		'whitelabel.useDropdownApploader': [_.isBoolean, false],
 		bypassAppStorePermissions: [_.isBoolean, false],
 		'whitelabel.disableFirstUseWalkthrough': [_.isBoolean, false],
-		'whitelabel.invoiceRangeConfig': [_.isNumber, 6]
+		'whitelabel.invoiceRangeConfig': [_.isNumber, 6],
+		'whitelabel.ttsVoice': [_.isString, defaultTTSVoice]
 	};
 
 	var featureSets = {
@@ -1126,6 +1128,7 @@ define(function(require) {
 	monster.initConfig = initConfig;
 	monster.setDefaultLanguage = setDefaultLanguage;
 	monster.supportedLanguages = supportedLanguages;
+	monster.defaultTTSVoice = defaultTTSVoice;
 
 	// We added this so Google Maps could execute a callback in the global namespace
 	// See example in Cluster Manager

--- a/src/js/lib/monster.js
+++ b/src/js/lib/monster.js
@@ -24,7 +24,8 @@ define(function(require) {
 		'es-ES',
 		'fr-FR',
 		'nl-NL',
-		'ru-RU'
+		'ru-RU',
+		'nl-BE'
 	];
 
 	var defaultConfig = {


### PR DESCRIPTION
- Adding `nl-BE` as a supported language in the Account and User settings
- Enabling `whitelabel` support for `tts.voice` changes in SmartPBX