### PR TITLE
MSPB-392: Restore E911 street line for Dash

### DIFF
--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -231,7 +231,12 @@ define(function(require) {
 				return;
 			}
 
-			data.full_street_address = _.get(data, 'legacy_data.house_number') + ' ' + _.get(data, 'street_address');
+			var streetAddress = _.get(data, 'street_address', ''),
+				houseNumber = _.get(data, 'legacy_data.house_number', ''),
+				streetStartsWithHouse = _.startsWith(streetAddress, houseNumber),
+				fullStreetAddress = streetStartsWithHouse || _.isEmpty(houseNumber) ? streetAddress : _.trim([houseNumber, streetAddress].join(' '));
+
+			data.full_street_address = fullStreetAddress;
 			return _.merge({}, data, {
 				notification_contact_emails: _
 					.chain(data)
@@ -242,12 +247,20 @@ define(function(require) {
 		},
 
 		e911Normalize: function(data) {
-			var splitAddress = data.street_address.split(/\s/g);
+			var streetAddress = _.trim(_.get(data, 'street_address', '')),
+				splitAddress = streetAddress.split(/\s+/g),
+				houseNumber = _.head(splitAddress),
+				existingLegacyData = _.get(data, 'legacy_data', {}),
+				legacyData = _.isPlainObject(existingLegacyData) ? _.clone(existingLegacyData) : {};
+
 			data.caller_name = monster.apps.auth.currentAccount.name;
-			data.legacy_data = {
-				house_number: _.head(splitAddress)
-			};
-			data.street_address = splitAddress.slice(1).join(' ');
+			data.street_address = streetAddress;
+
+			if (/^\d/.test(houseNumber)) {
+				legacyData.house_number = houseNumber;
+			}
+
+			data.legacy_data = legacyData;
 
 			return _.merge({}, data, {
 				notification_contact_emails: _


### PR DESCRIPTION
**Summary**

Restores the E911 street format to ensure **Dash** receives the full street address while **Intrado** maintains its split house number for provisioning consistency.

**Implementation Details**

* **`e911Normalize`**

  * Trims the `street` field.
  * Stores the complete street line in `street_address`.
  * Extracts only the leading numeric token into `legacy_data.house_number`, preserving all other legacy metadata.

* **`e911Format`**

  * Displays the stored `street_address` value directly.
  * Prepends the legacy house number only when required.
  * Prevents duplicated house numbers from appearing in the UI modal.

**Provider Behavior and Validation**

**Dash (Bandwidth)**

* Receives payloads in the expected schema, enabling successful geocoding.

  ```json
  {
    "street_address": "188 DOVE CIR",
    "legacy_data": { "house_number": "188" }
  }
  ```
* Matches Bandwidth’s [E911 schema](https://dev.bandwidth.com/apis/emergency-apis/dash/#tag/URIs/operation/getLocationsByUri), where full street and house number are handled independently.

Example response from Dash API:

```xml
<ns0:getLocationsByURIResponse xmlns:ns0="http://dashcs.com/api/v1/emergency">
  <Locations>
    <address1>1855 BLAKE ST</address1>
    <legacydata>
      <housenumber>1855</housenumber>
      <streetname>BLAKE ST</streetname>
    </legacydata>
    <status>
      <code>PROVISIONED</code>
      <description>Location is currently provisioned for URI</description>
    </status>
  </Locations>
</ns0:getLocationsByURIResponse>
```

**Intrado**

* Continues to receive the full street line along with the split house number.
* Provisioning remains successful, and coordinate differences are limited to rounding precision.

**Before**

```json
"e911": {
  "street_address": "DOVE CIR",
  "legacy_data": { "house_number": "188" },
  "latitude": "26.703117",
  "longitude": "-80.2129098"
}
```

**After Code Change**

```json
"e911": {
  "street_address": "188 DOVE CIR",
  "legacy_data": { "house_number": "188" },
  "latitude": "26.70311",
  "longitude": "-80.2129"
}
```

**Testing and Coverage**

* Verified across **Smart PBX Numbers**, **Main Number**, and **Caller ID** modals.
* Tested in both **Dash** and **Intrado** environments.
* Payloads remain identical across all flows, and provisioning completes successfully in all cases.
