### PR TITLE
MSTR-351: Fix e911 save logic in e911Normalize

### DIFF
--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -247,20 +247,8 @@ define(function(require) {
 		},
 
 		e911Normalize: function(data) {
-			var streetAddress = _.trim(_.get(data, 'street_address', '')),
-				splitAddress = streetAddress.split(/\s+/g),
-				houseNumber = _.head(splitAddress),
-				existingLegacyData = _.get(data, 'legacy_data', {}),
-				legacyData = _.isPlainObject(existingLegacyData) ? _.clone(existingLegacyData) : {};
-
 			data.caller_name = monster.apps.auth.currentAccount.name;
-			data.street_address = streetAddress;
-
-			if (/^\d/.test(houseNumber)) {
-				legacyData.house_number = houseNumber;
-			}
-
-			data.legacy_data = legacyData;
+			data.street_address = _.trim(_.get(data, 'street_address', ''));
 
 			return _.merge({}, data, {
 				notification_contact_emails: _


### PR DESCRIPTION
- Stop splitting `street_address` and constructing `legacy_data` client-side on save
- Send complete `street_address` to the API as-is, backend owns `legacy_data` decomposition ([KINT-2](https://oomacorp.atlassian.net/browse/KINT-2))

## Changes

- `src/apps/common/submodules/e911/e911.js` -- `e911Normalize` save logic cleanup

## Test Plan

- [ ] Verify saving E911 via Numbers > DID > E911 sends complete `street_address`
- [ ] Verify display still works correctly (`e911Format` guard unchanged from `MSPB-392`)
- [ ] Confirm [KINT-2](https://oomacorp.atlassian.net/browse/KINT-2) is done/merged before testing save behaviour, as backend now owns `legacy_data` decomposition

## Ticket

MSTR-351: E911 stop constructing `legacy_data` client-side in `e911Normalize`
https://oomacorp.atlassian.net/browse/MSTR-351
