### PR TITLE
MSTR-352: Add Canada country support to E911 form

### DIFF
--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -754,6 +754,24 @@
 			"us": {
 				"value": "US",
 				"option": "United States"
+			},
+			"ca": {
+				"value": "CA",
+				"option": "Canada"
+			}
+		},
+		"labels": {
+			"us": {
+				"postalCode": "Zip Code",
+				"region": "State",
+				"postalPlaceholder": "12345",
+				"regionPlaceholder": "CA"
+			},
+			"ca": {
+				"postalCode": "Postal Code",
+				"region": "Province",
+				"postalPlaceholder": "A1A 1A1",
+				"regionPlaceholder": "ON"
 			}
 		}
 	},

--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -759,6 +759,16 @@
 				"value": "CA",
 				"option": "Canada"
 			}
+		},
+		"placeholders": {
+			"us": {
+				"postalCode": "12345",
+				"region": "CA"
+			},
+			"ca": {
+				"postalCode": "A1A 1A1",
+				"region": "ON"
+			}
 		}
 	},
 

--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -726,7 +726,7 @@
 			"label": "Email Address(es)",
 			"placeholder": "Space separated"
 		},
-		"addressLine1": "Address Line 1",
+		"addressLine1": "Address",
 		"addressLine2": "Extended Address",
 		"city": "City",
 		"dialogTitle": "Edit 911 Location",
@@ -734,9 +734,12 @@
 		"infoBox": "This information will show up to 911 emergency services when you dial it from your number.",
 		"label": "e911",
 		"lastE911Error": "You must have e911 set up on at least one number in your account. Please set it up on another number before removing it from this one.",
-		"postalCode": "Zip/Postal Code",
+		"postalCode": "Zip Code",
 		"rotatedText": "For emergency services",
-		"state": "State/Province",
+		"state": {
+			"label": "State",
+			"placeholder": "2-letter code"
+		},
 		"country": "Country",
 		"successE911": "You successfully updated the e911 information of <br> {{phoneNumber}}",
 		"title": "E911 Information",
@@ -753,21 +756,21 @@
 		"countries": {
 			"us": {
 				"value": "US",
-				"option": "United States"
-			},
-			"canada": {
-				"value": "CA",
-				"option": "Canada"
-			}
-		},
-		"placeholders": {
-			"us": {
-				"postalCode": "12345",
-				"region": "CA"
+				"option": "United States",
+				"postalCode": {
+					"label": "Zip Code",
+					"placeholder": "12345"
+				},
+				"region": "State"
 			},
 			"ca": {
-				"postalCode": "A1A 1A1",
-				"region": "ON"
+				"value": "CA",
+				"option": "Canada",
+				"postalCode": {
+					"label": "Postal Code",
+					"placeholder": "A1A 1A1"
+				},
+				"region": "Province"
 			}
 		}
 	},

--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -738,7 +738,7 @@
 		"rotatedText": "For emergency services",
 		"state": {
 			"label": "State",
-			"placeholder": "2-letter code"
+			"placeholder": "2 Letter Code"
 		},
 		"country": "Country",
 		"successE911": "You successfully updated the e911 information of <br> {{phoneNumber}}",

--- a/src/apps/common/i18n/en-US.json
+++ b/src/apps/common/i18n/en-US.json
@@ -727,16 +727,16 @@
 			"placeholder": "Space separated"
 		},
 		"addressLine1": "Address Line 1",
-		"addressLine2": "Address Line 2",
+		"addressLine2": "Extended Address",
 		"city": "City",
 		"dialogTitle": "Edit 911 Location",
 		"gmapPinLabel": "Your+E911+Location",
 		"infoBox": "This information will show up to 911 emergency services when you dial it from your number.",
 		"label": "e911",
 		"lastE911Error": "You must have e911 set up on at least one number in your account. Please set it up on another number before removing it from this one.",
-		"postalCode": "Zip Code",
+		"postalCode": "Zip/Postal Code",
 		"rotatedText": "For emergency services",
-		"state": "State",
+		"state": "State/Province",
 		"country": "Country",
 		"successE911": "You successfully updated the e911 information of <br> {{phoneNumber}}",
 		"title": "E911 Information",
@@ -755,23 +755,9 @@
 				"value": "US",
 				"option": "United States"
 			},
-			"ca": {
+			"canada": {
 				"value": "CA",
 				"option": "Canada"
-			}
-		},
-		"labels": {
-			"us": {
-				"postalCode": "Zip Code",
-				"region": "State",
-				"postalPlaceholder": "12345",
-				"regionPlaceholder": "CA"
-			},
-			"ca": {
-				"postalCode": "Postal Code",
-				"region": "Province",
-				"postalPlaceholder": "A1A 1A1",
-				"regionPlaceholder": "ON"
 			}
 		}
 	},

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -57,6 +57,14 @@ define(function(require) {
 				}
 			});
 
+			var initialCountry = _.get(dataNumber, 'e911.country', 'US');
+			popupHtml.find('select[name="country"]').val(initialCountry);
+			self.e911ApplyCountryUi(popupHtml, initialCountry);
+
+			popupHtml.find('select[name="country"]').on('change', function() {
+				self.e911ApplyCountryUi(popupHtml, $(this).val());
+			});
+
 			popupHtml.find('#postal_code').change(function() {
 				var zipCode = $(this).val();
 
@@ -224,6 +232,22 @@ define(function(require) {
 				top: 40 + rotatedTextOffset + 'px',
 				left: 25 - rotatedTextOffset + 'px'
 			});
+		},
+
+		e911ApplyCountryUi: function(form, country) {
+			var self = this,
+				key = (country || 'US').toLowerCase(),
+				i18nLabels = _.get(self.i18n.active(), 'e911.labels', {}),
+				labels = i18nLabels[key] || i18nLabels.us;
+
+			if (!labels) {
+				return;
+			}
+
+			form.find('label[for="postal_code"]').text(labels.postalCode);
+			form.find('#postal_code').attr('placeholder', labels.postalPlaceholder);
+			form.find('label[for="region"]').text(labels.region);
+			form.find('#region').attr('placeholder', labels.regionPlaceholder);
 		},
 
 		e911Format: function(data) {

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -60,6 +60,12 @@ define(function(require) {
 				}
 			});
 
+			self.e911ApplyCountryUi(popupHtml, _.get(dataNumber, 'e911.country', 'US'));
+
+			popupHtml.find('select[name="country"]').on('change', function() {
+				self.e911ApplyCountryUi(popupHtml, $(this).val());
+			});
+
 			popupHtml.find('#postal_code').change(function() {
 				var zipCode = $(this).val();
 
@@ -227,6 +233,20 @@ define(function(require) {
 				top: 40 + rotatedTextOffset + 'px',
 				left: 25 - rotatedTextOffset + 'px'
 			});
+		},
+
+		e911ApplyCountryUi: function(form, country) {
+			var self = this,
+				key = (country || 'US').toLowerCase(),
+				i18nPlaceholders = _.get(self.i18n.active(), 'e911.placeholders', {}),
+				hints = i18nPlaceholders[key] || i18nPlaceholders.us;
+
+			if (!hints) {
+				return;
+			}
+
+			form.find('#postal_code').attr('placeholder', hints.postalCode);
+			form.find('#region').attr('placeholder', hints.region);
 		},
 
 		e911Format: function(data) {

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -53,16 +53,11 @@ define(function(require) {
 				rules: {
 					notification_contact_emails: {
 						listOf: 'email'
+					},
+					region: {
+						maxlength: 2
 					}
 				}
-			});
-
-			var initialCountry = _.get(dataNumber, 'e911.country', 'US');
-			popupHtml.find('select[name="country"]').val(initialCountry);
-			self.e911ApplyCountryUi(popupHtml, initialCountry);
-
-			popupHtml.find('select[name="country"]').on('change', function() {
-				self.e911ApplyCountryUi(popupHtml, $(this).val());
 			});
 
 			popupHtml.find('#postal_code').change(function() {
@@ -232,22 +227,6 @@ define(function(require) {
 				top: 40 + rotatedTextOffset + 'px',
 				left: 25 - rotatedTextOffset + 'px'
 			});
-		},
-
-		e911ApplyCountryUi: function(form, country) {
-			var self = this,
-				key = (country || 'US').toLowerCase(),
-				i18nLabels = _.get(self.i18n.active(), 'e911.labels', {}),
-				labels = i18nLabels[key] || i18nLabels.us;
-
-			if (!labels) {
-				return;
-			}
-
-			form.find('label[for="postal_code"]').text(labels.postalCode);
-			form.find('#postal_code').attr('placeholder', labels.postalPlaceholder);
-			form.find('label[for="region"]').text(labels.region);
-			form.find('#region').attr('placeholder', labels.regionPlaceholder);
 		},
 
 		e911Format: function(data) {

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -62,6 +62,8 @@ define(function(require) {
 				}
 			});
 
+			monster.ui.valid(popupHtml);
+
 			self.e911ApplyCountryUi(popupHtml, _.get(dataNumber, 'e911.country', 'US'));
 
 			popupHtml.find('select[name="country"]').on('change', function() {

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -242,15 +242,16 @@ define(function(require) {
 		e911ApplyCountryUi: function(form, country) {
 			var self = this,
 				key = (country || 'US').toLowerCase(),
-				i18nPlaceholders = _.get(self.i18n.active(), 'e911.placeholders', {}),
-				hints = i18nPlaceholders[key] || i18nPlaceholders.us;
+				i18nCountries = _.get(self.i18n.active(), 'e911.countries', {}),
+				countryLabels = i18nCountries[key] || i18nCountries.us;
 
-			if (!hints) {
+			if (!countryLabels) {
 				return;
 			}
 
-			form.find('#postal_code').attr('placeholder', hints.postalCode);
-			form.find('#region').attr('placeholder', hints.region);
+			form.find('label[for="postal_code"]').text(_.get(countryLabels, 'postalCode.label'));
+			form.find('#postal_code').attr('placeholder', _.get(countryLabels, 'postalCode.placeholder'));
+			form.find('label[for="region"]').text(_.get(countryLabels, 'region'));
 		},
 
 		e911Format: function(data) {

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -55,9 +55,9 @@ define(function(require) {
 						listOf: 'email'
 					},
 					region: {
+						lettersonly: true,
 						minlength: 2,
-						maxlength: 2,
-						lettersonly: true
+						maxlength: 2
 					}
 				}
 			});

--- a/src/apps/common/submodules/e911/e911.js
+++ b/src/apps/common/submodules/e911/e911.js
@@ -55,7 +55,9 @@ define(function(require) {
 						listOf: 'email'
 					},
 					region: {
-						maxlength: 2
+						minlength: 2,
+						maxlength: 2,
+						lettersonly: true
 					}
 				}
 			});

--- a/src/apps/common/submodules/e911/e911.scss
+++ b/src/apps/common/submodules/e911/e911.scss
@@ -44,6 +44,10 @@
 
 	.control-group {
 		margin-bottom: 10px;
+
+		label.monster-invalid {
+			position: unset;
+		}
 	}
 
 	.control-group .control-label {

--- a/src/apps/common/submodules/e911/e911.scss
+++ b/src/apps/common/submodules/e911/e911.scss
@@ -47,6 +47,9 @@
 
 		label.monster-invalid {
 			position: unset;
+			max-width: 196px;
+			white-space: normal;
+			word-wrap: break-word;
 		}
 	}
 

--- a/src/apps/common/submodules/e911/views/dialog.html
+++ b/src/apps/common/submodules/e911/views/dialog.html
@@ -43,8 +43,11 @@
 				<label class="control-label" for="country">{{ i18n.e911.country }}</label>
 				<div class="controls">
 					<select class="country-list" name="country">
-						<option value="{{ i18n.e911.countries.us.value }}" selected>
+						<option value="{{ i18n.e911.countries.us.value }}">
 							{{ i18n.e911.countries.us.option }}
+						</option>
+						<option value="{{ i18n.e911.countries.ca.value }}">
+							{{ i18n.e911.countries.ca.option }}
 						</option>
 					</select>
 				</div>

--- a/src/apps/common/submodules/e911/views/dialog.html
+++ b/src/apps/common/submodules/e911/views/dialog.html
@@ -12,13 +12,13 @@
 			<div class="control-group">
 				<label class="control-label" for="postal_code">{{ i18n.e911.postalCode }}</label>
 				<div class="controls">
-					<input id="postal_code" type="text" placeholder='{{ i18n.e911.placeholders.us.postalCode }}' name="postal_code" value="{{postal_code}}"/>
+					<input id="postal_code" required type="text" placeholder='{{ i18n.e911.placeholders.us.postalCode }}' name="postal_code" value="{{postal_code}}"/>
 				</div>
 			</div>
 			<div class="control-group">
 				<label class="control-label" for="street_address">{{ i18n.e911.addressLine1 }}</label>
 				<div class="controls">
-					<input id="street_address" type="text" placeholder='{{ i18n.e911.addressLine1 }}' name="street_address" value="{{full_street_address}}" />
+					<input id="street_address" required type="text" placeholder='{{ i18n.e911.addressLine1 }}' name="street_address" value="{{full_street_address}}" />
 				</div>
 			</div>
 			<div class="control-group">
@@ -30,13 +30,13 @@
 			<div class="control-group">
 				<label class="control-label" for="locality">{{ i18n.e911.city }}</label>
 				<div class="controls">
-					<input id="locality" type="text" name="locality" placeholder='{{ i18n.e911.city }}' value="{{locality}}" />
+					<input id="locality" required type="text" name="locality" placeholder='{{ i18n.e911.city }}' value="{{locality}}" />
 				</div>
 			</div>
 			<div class="control-group">
 				<label class="control-label" for="region">{{ i18n.e911.state }}</label>
 				<div class="controls">
-					<input id="region" type="text" name="region" placeholder='{{ i18n.e911.placeholders.us.region }}' value="{{region}}" />
+					<input id="region" required type="text" name="region" placeholder='{{ i18n.e911.placeholders.us.region }}' value="{{region}}" />
 				</div>
 			</div>
 			<div class="control-group">

--- a/src/apps/common/submodules/e911/views/dialog.html
+++ b/src/apps/common/submodules/e911/views/dialog.html
@@ -43,12 +43,14 @@
 				<label class="control-label" for="country">{{ i18n.e911.country }}</label>
 				<div class="controls">
 					<select class="country-list" name="country">
-						<option value="{{ i18n.e911.countries.us.value }}">
+						{{#select country}}
+						<option value="{{ i18n.e911.countries.canada.value }}">
+							{{ i18n.e911.countries.canada.option }}
+						</option>
+						<option value="{{ i18n.e911.countries.us.value }}" selected>
 							{{ i18n.e911.countries.us.option }}
 						</option>
-						<option value="{{ i18n.e911.countries.ca.value }}">
-							{{ i18n.e911.countries.ca.option }}
-						</option>
+						{{/select}}
 					</select>
 				</div>
 			</div>

--- a/src/apps/common/submodules/e911/views/dialog.html
+++ b/src/apps/common/submodules/e911/views/dialog.html
@@ -45,7 +45,7 @@
 			<div class="control-group">
 				<label class="control-label" for="region">{{ i18n.e911.state.label }}</label>
 				<div class="controls">
-					<input id="region" required type="text" name="region" placeholder='{{ i18n.e911.state.placeholder }}' value="{{region}}" />
+					<input id="region" required type="text" maxlength="2" name="region" placeholder='{{ i18n.e911.state.placeholder }}' value="{{region}}" />
 				</div>
 			</div>
 			<div class="control-group">

--- a/src/apps/common/submodules/e911/views/dialog.html
+++ b/src/apps/common/submodules/e911/views/dialog.html
@@ -10,9 +10,18 @@
 
 		<div class="pull-left">
 			<div class="control-group">
-				<label class="control-label" for="postal_code">{{ i18n.e911.postalCode }}</label>
+				<label class="control-label" for="country">{{ i18n.e911.country }}</label>
 				<div class="controls">
-					<input id="postal_code" required type="text" placeholder='{{ i18n.e911.placeholders.us.postalCode }}' name="postal_code" value="{{postal_code}}"/>
+					<select class="country-list" name="country">
+						{{#select country}}
+						<option value="{{ i18n.e911.countries.us.value }}">
+							{{ i18n.e911.countries.us.option }}
+						</option>
+						<option value="{{ i18n.e911.countries.ca.value }}">
+							{{ i18n.e911.countries.ca.option }}
+						</option>
+						{{/select}}
+					</select>
 				</div>
 			</div>
 			<div class="control-group">
@@ -34,24 +43,15 @@
 				</div>
 			</div>
 			<div class="control-group">
-				<label class="control-label" for="region">{{ i18n.e911.state }}</label>
+				<label class="control-label" for="region">{{ i18n.e911.state.label }}</label>
 				<div class="controls">
-					<input id="region" required type="text" name="region" placeholder='{{ i18n.e911.placeholders.us.region }}' value="{{region}}" />
+					<input id="region" required type="text" name="region" placeholder='{{ i18n.e911.state.placeholder }}' value="{{region}}" />
 				</div>
 			</div>
 			<div class="control-group">
-				<label class="control-label" for="country">{{ i18n.e911.country }}</label>
+				<label class="control-label" for="postal_code">{{ i18n.e911.postalCode }}</label>
 				<div class="controls">
-					<select class="country-list" name="country">
-						{{#select country}}
-						<option value="{{ i18n.e911.countries.canada.value }}">
-							{{ i18n.e911.countries.canada.option }}
-						</option>
-						<option value="{{ i18n.e911.countries.us.value }}" selected>
-							{{ i18n.e911.countries.us.option }}
-						</option>
-						{{/select}}
-					</select>
+					<input id="postal_code" required type="text" placeholder='{{ i18n.e911.placeholders.us.postalCode }}' name="postal_code" value="{{postal_code}}"/>
 				</div>
 			</div>
 			{{#if status}}

--- a/src/apps/common/submodules/e911/views/dialog.html
+++ b/src/apps/common/submodules/e911/views/dialog.html
@@ -12,7 +12,7 @@
 			<div class="control-group">
 				<label class="control-label" for="postal_code">{{ i18n.e911.postalCode }}</label>
 				<div class="controls">
-					<input id="postal_code" type="text" placeholder='{{ i18n.e911.postalCode }}' name="postal_code" value="{{postal_code}}"/>
+					<input id="postal_code" type="text" placeholder='{{ i18n.e911.placeholders.us.postalCode }}' name="postal_code" value="{{postal_code}}"/>
 				</div>
 			</div>
 			<div class="control-group">
@@ -36,7 +36,7 @@
 			<div class="control-group">
 				<label class="control-label" for="region">{{ i18n.e911.state }}</label>
 				<div class="controls">
-					<input id="region" type="text" name="region" placeholder='{{ i18n.e911.state }}' value="{{region}}" />
+					<input id="region" type="text" name="region" placeholder='{{ i18n.e911.placeholders.us.region }}' value="{{region}}" />
 				</div>
 			</div>
 			<div class="control-group">


### PR DESCRIPTION
Adds Canada to the country selector in the common `e911` dialog. Labels and placeholders react to the selected country.

## Note

Backend wiring for Canadian addresses lives on [KINT-3](https://oomacorp.atlassian.net/browse/KINT-3) (`kazoo-intrado` integration).

## Ticket

[MSTR-352](https://oomacorp.atlassian.net/browse/MSTR-352), sibling [MSPB-406](https://oomacorp.atlassian.net/browse/MSPB-406)
