### PR TITLE
MSTR-367: Increase height of app items in App Exchange

### DIFF
--- a/src/apps/appstore/style/app.scss
+++ b/src/apps/appstore/style/app.scss
@@ -173,7 +173,7 @@
 
 #appstore_container .right-content .right-container .app-element {
 	width: 270px;
-	height: 110px;
+	height: 126px;
 	border: solid 1px #ccc;
 	float: left;
 	padding: 20px 15px;
@@ -249,7 +249,7 @@
 }
 
 #appstore_container .right-content .right-container .app-element-right .app-description {
-	height: 80px;
+	height: 96px;
 	overflow: hidden;
 	font-size: 12px;
 }


### PR DESCRIPTION
Increase the height of app items in App Exchange to allow displaying longer app descriptions.

### Screenshots
<img width="3598" height="2070" alt="CleanShot 2026-08-13 at 11 13 16@2x" src="https://github.com/user-attachments/assets/5b0b80ee-bb4d-4024-831f-a73f1dd7d9f0" />
