### PR TITLE
[5.4] MSTR-367: Increase height of app items in App Exchange

### DIFF
--- a/src/apps/appstore/style/app.scss
+++ b/src/apps/appstore/style/app.scss
@@ -173,7 +173,7 @@
 
 #appstore_container .right-content .right-container .app-element {
 	width: 270px;
-	height: 110px;
+	height: 126px;
 	border: solid 1px #ccc;
 	float: left;
 	padding: 20px 15px;
@@ -249,7 +249,7 @@
 }
 
 #appstore_container .right-content .right-container .app-element-right .app-description {
-	height: 80px;
+	height: 96px;
 	overflow: hidden;
 	font-size: 12px;
 }


### PR DESCRIPTION
Increase the height of app items in App Exchange to allow displaying longer app descriptions.

Main PR: https://github.com/2600hz/monster-ui/pull/1417